### PR TITLE
LLVM-IR initial support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,9 +704,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "calloop"
@@ -1125,6 +1125,27 @@ checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2348,6 +2369,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
+name = "llvm-ir"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7c7f889914dd7f097b2b917cc2a31b2e40cf9eb1af9d56b0cf1ba1fad37b48"
+dependencies = [
+ "either",
+ "llvm-sys",
+ "log",
+ "ordered-float 4.6.0",
+]
+
+[[package]]
+name = "llvm-sys"
+version = "191.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893cddf1adf0354b93411e413553dd4daf5c43195d73f1acfa1e394bdd371456"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "microlp"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54df3293c9060b47f9953c8785e5c96e3d3c29e48afaf215f3f335ffc7007304"
+checksum = "edaa5264bc1f7668bc12e10757f8f529a526656c796cc2106cf2be10c5b8d483"
 dependencies = [
  "log",
  "sprs",
@@ -3417,6 +3464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,6 +3649,7 @@ dependencies = [
  "clap_derive",
  "delegate",
  "derivative",
+ "derive_more",
  "dir-test",
  "dot-structures",
  "either",
@@ -3604,6 +3658,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.14.0",
+ "llvm-ir",
  "num",
  "pest",
  "pest-ast",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sd-visualiser also supports LLVM MLIR [4], and can be used to visualise MLIR pro
 ### Web
 
 Please go to <https://sd-visualiser.github.io/sd-visualiser/> to use the web version of the visualiser.
-Minor features such as faster layout are not available in the web version.
+Support for LLVM IR, along with other minor features, such as faster layout, are not available in the web version.
 
 ### Linux (Ubuntu)
 

--- a/examples/llvm-ir/add.ll
+++ b/examples/llvm-ir/add.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e293c764365fd92f0d92ab0ee9c1cf37fdfb9df5278687b482a0eca15445a62
+size 342

--- a/examples/llvm-ir/alias.ll
+++ b/examples/llvm-ir/alias.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ed586c4105a6f7f0c3d0206cea71c078c7e1e6f0b30abc1e14ac078aa11bd97
+size 294

--- a/examples/llvm-ir/diverge.ll
+++ b/examples/llvm-ir/diverge.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab5dd94e085fc6ad79299757f434f597df36ba0f7edd5ad7dd9180c083d3b1db
+size 72

--- a/examples/llvm-ir/fact.ll
+++ b/examples/llvm-ir/fact.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:304f12ce9e9746b47841d08d52c218926f244413f238c026ea1e1b516f6c85a7
+size 1740

--- a/examples/llvm-ir/hello.ll
+++ b/examples/llvm-ir/hello.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3655b1041f8afc37329c5a515c15d3a6b83e7bdee15c15f565a45b48c99c0e2a
+size 947

--- a/examples/llvm-ir/ifunc.ll
+++ b/examples/llvm-ir/ifunc.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9d8d31836a6efbab01b07da3e0157908340e12d54c7b6e30b7df664db28d38
+size 708

--- a/examples/llvm-ir/jump.ll
+++ b/examples/llvm-ir/jump.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb27b2674978bb21a7d5b8f5fe1496fde0c1edf6e18de22abe6623bae409b2ee
+size 65

--- a/examples/llvm-ir/linkedlist.ll
+++ b/examples/llvm-ir/linkedlist.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f73f9951a93efc367bbad8678ebef453deb46e23b177e57157f90bae2193d08
+size 7130

--- a/examples/llvm-ir/loop.ll
+++ b/examples/llvm-ir/loop.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7396d2b86d109093c47d0b3b149d847298431c4338e60aa626a0a590e30c45c
+size 4392

--- a/examples/llvm-ir/mutual_diverge.ll
+++ b/examples/llvm-ir/mutual_diverge.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c44cff33c8ecd795b5694677cf883af5c357c3719adb49f055b2b686f3e9d82e
+size 149

--- a/examples/llvm-ir/switch.ll
+++ b/examples/llvm-ir/switch.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efc4b71fbee582dc3cf3554e638196f0e2f9be868bdcd1079324e462fb33df4d
+size 2350

--- a/examples/llvm-ir/variables.ll
+++ b/examples/llvm-ir/variables.ll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3370bcfe430e1dc4f11adc763966ba9f90de6e662268460821bcfa3ff96f3138
+size 3097

--- a/flake.nix
+++ b/flake.nix
@@ -70,15 +70,27 @@
           nci = {
             projects.sd = {
               path = ./.;
+              depsDrvConfig.mkDerivation = {
+                nativeBuildInputs = with pkgs; [
+                  llvm_19.dev
+                ];
+              };
               profiles.dev = { };
               profiles.release = {
                 runTests = false;
               };
             };
+
             crates = {
               sd-gui = {
                 targets."x86_64-unknown-linux-gnu" = {
                   default = true;
+                  drvConfig.mkDerivation = {
+                    nativeBuildInputs = with pkgs; [
+                      libz
+                      libxml2
+                    ];
+                  };
                 };
 
                 targets."wasm32-unknown-unknown" = {
@@ -106,6 +118,7 @@
                 };
 
                 runtimeLibs = with pkgs; [
+                  stdenv.cc.cc.lib
                   libGL
                   libxkbcommon
                   wayland

--- a/non_test_examples/c/add.c
+++ b/non_test_examples/c/add.c
@@ -1,0 +1,9 @@
+// https://aosabook.org/en/v1/llvm.html
+unsigned add1(unsigned a, unsigned b) { return a + b; }
+
+// Perhaps not the most efficient way to add two numbers.
+unsigned add2(unsigned a, unsigned b) {
+  if (a == 0)
+    return b;
+  return add2(a - 1, b + 1);
+}

--- a/non_test_examples/c/fact.c
+++ b/non_test_examples/c/fact.c
@@ -1,0 +1,9 @@
+// factorial function
+
+int fact(int n) {
+  if (n == 0) {
+    return 1;
+  } else {
+    return n * fact(n - 1);
+  }
+}

--- a/sd-core/Cargo.toml
+++ b/sd-core/Cargo.toml
@@ -20,7 +20,6 @@ from-pest = "0.3.3"
 good_lp = { version = "1.12.0", default-features = false, features = [ "clarabel" ] }
 indexmap = "2.7.1"
 itertools = "0.14.0"
-llvm-ir = { version = "0.11.2", features = ["llvm-19"] }
 num = "0.4.3"
 pest = "2.7.15"
 pest-ast = "0.3.5"
@@ -31,6 +30,9 @@ priority-queue = "2.1.2"
 qcell = "0.5.4"
 thiserror = "2.0.11"
 tracing = "0.1.41"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+llvm-ir = { version = "0.11.2", features = ["llvm-19"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 good_lp = { version = "1.12.0", default-features = false, features = [ "clarabel-wasm" ] }

--- a/sd-core/Cargo.toml
+++ b/sd-core/Cargo.toml
@@ -13,12 +13,14 @@ clap = "4.5.30"
 clap_derive = "4.5.28"
 delegate = "0.13.2"
 derivative = "2.2.0"
+derive_more = { version = "2.0.1", features = ["display", "from"] }
 dot-structures = "0.1.1"
 either = "1.14.0"
 from-pest = "0.3.3"
 good_lp = { version = "1.12.0", default-features = false, features = [ "clarabel" ] }
 indexmap = "2.7.1"
 itertools = "0.14.0"
+llvm-ir = { version = "0.11.2", features = ["llvm-19"] }
 num = "0.4.3"
 pest = "2.7.15"
 pest-ast = "0.3.5"
@@ -49,3 +51,4 @@ microlp = ["good_lp/minilp"]
 cbc = ["good_lp/coin_cbc"]
 highs = ["good_lp/highs"]
 gurobi = ["good_lp/lp-solvers"]
+

--- a/sd-core/src/common.rs
+++ b/sd-core/src/common.rs
@@ -77,6 +77,18 @@ where
     }
 }
 
+impl Matchable for String {
+    fn is_match(&self, query: &str) -> bool {
+        self == query
+    }
+}
+
+impl Matchable for Box<String> {
+    fn is_match(&self, query: &str) -> bool {
+        self.as_ref() == query
+    }
+}
+
 impl<S: Matchable, T: Matchable> Matchable for Either<S, T> {
     fn is_match(&self, query: &str) -> bool {
         match self {

--- a/sd-core/src/free_vars.rs
+++ b/sd-core/src/free_vars.rs
@@ -97,6 +97,11 @@ impl<T: Language> Thunk<T> {
         sym_name_link: bool,
     ) {
         let mut new_vars: IndexSet<T::Var> = IndexSet::new();
+        if sym_name_link {
+            if let Ok(sym) = <T as Language>::Symbol::try_from(self.addr.clone()) {
+                to_remove.insert(sym.into());
+            }
+        }
         self.body
             .extend_free_vars(&mut new_vars, to_remove, sym_name_link);
         to_remove.extend(self.args.iter().map(|def| def.var().clone()));

--- a/sd-core/src/hypergraph/petgraph.rs
+++ b/sd-core/src/hypergraph/petgraph.rs
@@ -11,7 +11,7 @@ use super::{
 
 pub type PetGraph<V, E> = petgraph::Graph<PetNode<V, E>, usize>;
 
-#[cfg_attr(test, derive(Serialize))]
+#[cfg_attr(test, derive(Debug, Serialize))]
 pub enum PetNode<V, E> {
     Edge(E),
     Operation(V),

--- a/sd-core/src/language/chil.rs
+++ b/sd-core/src/language/chil.rs
@@ -29,6 +29,14 @@ impl super::Language for Chil {
     type Symbol = Empty;
 }
 
+impl TryFrom<<Chil as super::Language>::Addr> for <Chil as super::Language>::Symbol {
+    type Error = &'static str;
+
+    fn try_from(_: <Chil as super::Language>::Addr) -> Result<Self, Self::Error> {
+        Err("no symbols in chil")
+    }
+}
+
 pub type Expr = super::Expr<Chil>;
 pub type Bind = super::Bind<Chil>;
 pub type Value = super::Value<Chil>;

--- a/sd-core/src/language/llvm_ir.rs
+++ b/sd-core/src/language/llvm_ir.rs
@@ -1,0 +1,670 @@
+use derive_more::{Display, From};
+use either::Either;
+use itertools::Itertools;
+use llvm_ir::{
+    BasicBlock, Constant, ConstantRef, FPPredicate, Function, Instruction, IntPredicate, Module,
+    Name, Operand, Terminator,
+    instruction::{InlineAssembly, RMWBinOp},
+    module::{GlobalAlias, GlobalIFunc, GlobalVariable},
+};
+use tracing::debug;
+
+use super::{CF, Fresh, Language, OpInfo};
+use crate::{
+    common::Matchable,
+    hypergraph::traits::{WireType, WithType},
+};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct LlvmIrSettings {
+    pub sym_name_linking: bool,
+}
+
+impl Default for LlvmIrSettings {
+    fn default() -> Self {
+        Self {
+            sym_name_linking: true,
+        }
+    }
+}
+
+pub struct LlvmIr;
+
+pub type Expr = super::Expr<LlvmIr>;
+pub type Bind = super::Bind<LlvmIr>;
+pub type Value = super::Value<LlvmIr>;
+pub type Thunk = super::Thunk<LlvmIr>;
+pub type Block = super::Block<LlvmIr>;
+
+impl Language for LlvmIr {
+    type Op = Op;
+    type Var = Var;
+    type Addr = String;
+    type VarDef = Var;
+    type BlockAddr = Name;
+    type Symbol = Box<String>;
+}
+
+#[derive(Clone, PartialEq, Debug, Hash, Display, From)]
+pub enum Op {
+    // constant-like
+    Constant(ConstantRef),
+    RMWBinOp(RMWBinOp),
+    IntPredicate(IntPredicate),
+    FPPredicate(FPPredicate),
+    // globals
+    #[display("inline assembly")]
+    InlineAssembly(InlineAssembly),
+    #[display("{}", _0.name)]
+    GlobalVariable(GlobalVariable),
+    #[display("{}", _0.name)]
+    GlobalAlias(GlobalAlias),
+    #[display("{}", _0.name)]
+    GlobalIFunc(GlobalIFunc),
+    // end of basic block
+    Terminator(Terminator),
+    // LLVM machine instructions
+    Instruction(Instruction),
+}
+
+impl Eq for Op {}
+
+impl Matchable for Op {
+    fn is_match(&self, query: &str) -> bool {
+        format!("{}", self).contains(query)
+    }
+}
+
+impl OpInfo<LlvmIr> for Op {
+    fn get_cf(&self) -> Option<CF<LlvmIr>> {
+        match self {
+            Op::Terminator(Terminator::Ret(_)) => Some(CF::Return),
+            Op::Terminator(terminator) => Some(CF::Brs(match terminator {
+                Terminator::Ret(_ret) => unreachable!(),
+                Terminator::Br(br) => vec![br.dest.clone()],
+                Terminator::CondBr(cond_br) => {
+                    vec![cond_br.true_dest.clone(), cond_br.false_dest.clone()]
+                }
+                Terminator::Switch(switch) => [
+                    switch
+                        .dests
+                        .iter()
+                        .map(|(_val, dest)| dest)
+                        .cloned()
+                        .collect(),
+                    vec![switch.default_dest.clone()],
+                ]
+                .concat(),
+                Terminator::IndirectBr(indirect_br) => indirect_br.possible_dests.clone(),
+                Terminator::Invoke(invoke) => vec![
+                    invoke.result.clone(),
+                    invoke.return_label.clone(),
+                    invoke.exception_label.clone(),
+                ],
+                Terminator::Resume(_resume) => Vec::default(),
+                Terminator::Unreachable(_unreachable) => Vec::default(),
+                Terminator::CleanupRet(cleanup_ret) => {
+                    cleanup_ret.unwind_dest.iter().cloned().collect()
+                }
+                Terminator::CatchRet(catch_ret) => vec![catch_ret.successor.clone()],
+                Terminator::CatchSwitch(catch_switch) => [
+                    catch_switch.catch_handlers.clone(),
+                    catch_switch.default_unwind_dest.iter().cloned().collect(),
+                    vec![catch_switch.result.clone()],
+                ]
+                .concat(),
+                Terminator::CallBr(call_br) => {
+                    vec![call_br.result.clone(), call_br.return_label.clone()]
+                }
+            })),
+            _ => None,
+        }
+    }
+
+    fn symbols_used(&self) -> impl Iterator<Item = <LlvmIr as Language>::Symbol> {
+        match self {
+            Op::Constant(c) => match c.as_ref() {
+                Constant::GlobalReference {
+                    name: Name::Name(sym_name),
+                    ..
+                } => Some(sym_name.to_owned()),
+                _ => None,
+            },
+            _ => None,
+        }
+        .into_iter()
+    }
+
+    fn sym_name(&self) -> Option<<LlvmIr as Language>::Symbol> {
+        match self {
+            Op::GlobalVariable(global_variable) => match &global_variable.name {
+                Name::Name(name) => Some(name.to_owned()),
+                _ => None,
+            },
+            Op::GlobalAlias(global_alias) => match &global_alias.name {
+                Name::Name(name) => Some(name.to_owned()),
+                _ => None,
+            },
+            Op::GlobalIFunc(global_ifunc) => match &global_ifunc.name {
+                Name::Name(name) => Some(name.to_owned()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Hash, Debug, Display, From)]
+pub enum Var {
+    Var {
+        name: Name,
+    },
+    Symbol {
+        symbol: <LlvmIr as Language>::Symbol,
+    },
+    Metadata,
+}
+
+impl Eq for Var {}
+
+impl Matchable for Var {
+    fn is_match(&self, query: &str) -> bool {
+        match self {
+            Self::Var { name } => name.is_match(query),
+            Self::Symbol { symbol } => symbol.is_match(query),
+            Self::Metadata => false,
+        }
+    }
+}
+
+impl Fresh for Var {
+    fn fresh(number: usize) -> Self {
+        Name::from(number).into()
+    }
+}
+
+impl WithType for Var {
+    fn get_type(&self) -> WireType {
+        match self {
+            Var::Symbol { .. } => WireType::SymName,
+            _ => WireType::Data,
+        }
+    }
+}
+
+impl Matchable for Name {
+    fn is_match(&self, query: &str) -> bool {
+        match self {
+            Name::Name(name) => **name == query,
+            Name::Number(_) => false,
+        }
+    }
+}
+
+// Conversion from `llvm_ir` crate types.
+
+impl From<Module> for Expr {
+    fn from(module: Module) -> Self {
+        Self {
+            binds: [
+                module.functions.into_iter().map_into().collect::<Vec<_>>(),
+                module.global_vars.into_iter().map_into().collect(),
+                module.global_aliases.into_iter().map_into().collect(),
+                module.global_ifuncs.into_iter().map_into().collect(),
+            ]
+            .concat(),
+            values: Vec::default(),
+        }
+    }
+}
+
+impl From<Instruction> for Bind {
+    fn from(instr: Instruction) -> Self {
+        Bind {
+            defs: instr
+                .try_get_result()
+                .into_iter()
+                .cloned()
+                .map_into()
+                .collect(),
+            value: instr.into(),
+        }
+    }
+}
+
+impl From<Function> for Bind {
+    fn from(function: Function) -> Self {
+        Self {
+            defs: Vec::default(),
+            value: Value::Thunk(function.into()),
+        }
+    }
+}
+
+macro_rules! from_global_bind {
+    ($ty:ty) => {
+        impl From<$ty> for Bind {
+            fn from(global: $ty) -> Self {
+                Self {
+                    defs: Vec::default(),
+                    value: global.into(),
+                }
+            }
+        }
+    };
+}
+from_global_bind!(GlobalVariable);
+from_global_bind!(GlobalAlias);
+from_global_bind!(GlobalIFunc);
+
+impl From<Function> for Thunk {
+    fn from(function: Function) -> Self {
+        Thunk {
+            addr: function.name,
+            args: function
+                .parameters
+                .into_iter()
+                .map(|parameter| parameter.name.into())
+                .collect(),
+            body: Expr::default(),
+            blocks: function.basic_blocks.into_iter().map_into().collect(),
+        }
+    }
+}
+
+impl From<BasicBlock> for Block {
+    fn from(bb: BasicBlock) -> Self {
+        Block {
+            addr: bb.name,
+            args: Vec::default(),
+            expr: Expr {
+                binds: [
+                    bb.instrs.into_iter().map_into().collect(),
+                    vec![Bind {
+                        defs: Vec::default(),
+                        value: bb.term.into(),
+                    }],
+                ]
+                .concat(),
+                values: Vec::default(),
+            },
+        }
+    }
+}
+
+macro_rules! from_constant_value {
+    ($ty:ty, $variant:ident) => {
+        impl From<$ty> for Value {
+            fn from(c: $ty) -> Self {
+                Value::Op {
+                    op: Op::$variant(c.into()),
+                    args: Vec::default(),
+                }
+            }
+        }
+    };
+}
+from_constant_value!(ConstantRef, Constant);
+from_constant_value!(RMWBinOp, RMWBinOp);
+from_constant_value!(IntPredicate, IntPredicate);
+from_constant_value!(FPPredicate, FPPredicate);
+from_constant_value!(InlineAssembly, InlineAssembly);
+
+impl From<GlobalVariable> for Value {
+    fn from(global: GlobalVariable) -> Self {
+        Value::Op {
+            op: Op::GlobalVariable(global.clone()),
+            args: global.initializer.into_iter().map_into().collect(),
+        }
+    }
+}
+impl From<GlobalAlias> for Value {
+    fn from(global: GlobalAlias) -> Self {
+        Value::Op {
+            op: Op::GlobalAlias(global.clone()),
+            args: vec![global.aliasee.into()],
+        }
+    }
+}
+impl From<GlobalIFunc> for Value {
+    fn from(global: GlobalIFunc) -> Self {
+        Value::Op {
+            op: Op::GlobalIFunc(global.clone()),
+            args: vec![global.resolver_fn.into()],
+        }
+    }
+}
+
+impl From<Terminator> for Value {
+    fn from(term: Terminator) -> Self {
+        Value::Op {
+            op: Op::Terminator(term.clone()),
+            args: match term {
+                Terminator::Ret(ret) => ret.return_operand.into_iter().map_into().collect(),
+                Terminator::Br(_br) => Vec::default(),
+                Terminator::CondBr(cond_br) => vec![cond_br.condition.into()],
+                Terminator::Switch(switch) => vec![switch.operand.into()],
+                Terminator::IndirectBr(indirect_br) => vec![indirect_br.operand.into()],
+                Terminator::Invoke(invoke) => [
+                    vec![invoke.function.into()],
+                    invoke
+                        .arguments
+                        .into_iter()
+                        .map(|(arg, _attrs)| arg)
+                        .map_into()
+                        .collect(),
+                ]
+                .concat(),
+                Terminator::Resume(resume) => vec![resume.operand.into()],
+                Terminator::Unreachable(_unreachable) => Vec::default(),
+                Terminator::CleanupRet(cleanup_ret) => vec![cleanup_ret.cleanup_pad.into()],
+                Terminator::CatchRet(catch_ret) => vec![catch_ret.catch_pad.into()],
+                Terminator::CatchSwitch(catch_switch) => vec![catch_switch.parent_pad.into()],
+                Terminator::CallBr(call_br) => [
+                    vec![call_br.function.into()],
+                    call_br
+                        .arguments
+                        .into_iter()
+                        .map(|(arg, _attrs)| arg)
+                        .map_into()
+                        .collect(),
+                ]
+                .concat(),
+            },
+        }
+    }
+}
+
+impl From<Instruction> for Value {
+    fn from(instr: Instruction) -> Self {
+        Value::Op {
+            op: Op::Instruction(instr.clone()),
+            args: match instr {
+                // NB: the TODOs listed below signify extra information presented by `llvm-ir`, but
+                // currently ignored here
+                Instruction::Add(add) => vec![add.operand0.into(), add.operand1.into()],
+                Instruction::Sub(sub) => vec![sub.operand0.into(), sub.operand1.into()],
+                Instruction::Mul(mul) => vec![mul.operand0.into(), mul.operand1.into()],
+                Instruction::UDiv(udiv) => vec![udiv.operand0.into(), udiv.operand1.into()],
+                Instruction::SDiv(sdiv) => vec![sdiv.operand0.into(), sdiv.operand1.into()],
+                Instruction::URem(urem) => vec![urem.operand0.into(), urem.operand1.into()],
+                Instruction::SRem(srem) => vec![srem.operand0.into(), srem.operand1.into()],
+                Instruction::And(and) => vec![and.operand0.into(), and.operand1.into()],
+                Instruction::Or(or) => vec![or.operand0.into(), or.operand1.into()],
+                Instruction::Xor(xor) => vec![xor.operand0.into(), xor.operand1.into()],
+                Instruction::Shl(shl) => vec![shl.operand0.into(), shl.operand1.into()],
+                Instruction::LShr(lshr) => vec![lshr.operand0.into(), lshr.operand1.into()],
+                Instruction::AShr(ashr) => vec![ashr.operand0.into(), ashr.operand1.into()],
+                Instruction::FAdd(fadd) => vec![fadd.operand0.into(), fadd.operand1.into()],
+                Instruction::FSub(fsub) => vec![fsub.operand0.into(), fsub.operand1.into()],
+                Instruction::FMul(fmul) => vec![fmul.operand0.into(), fmul.operand1.into()],
+                Instruction::FDiv(fdiv) => vec![fdiv.operand0.into(), fdiv.operand1.into()],
+                Instruction::FRem(frem) => vec![frem.operand0.into(), frem.operand1.into()],
+                Instruction::FNeg(fneg) => vec![fneg.operand.into()],
+                Instruction::ExtractElement(extract_element) => {
+                    vec![extract_element.vector.into(), extract_element.index.into()]
+                }
+                Instruction::InsertElement(insert_element) => vec![
+                    insert_element.vector.into(),
+                    insert_element.element.into(),
+                    insert_element.index.into(),
+                ],
+                Instruction::ShuffleVector(shuffle_vector) => vec![
+                    shuffle_vector.operand0.into(),
+                    shuffle_vector.operand1.into(),
+                ],
+                Instruction::ExtractValue(extract_value) => [
+                    vec![extract_value.aggregate.into()],
+                    extract_value
+                        .indices
+                        .into_iter()
+                        .map(|idx| {
+                            Operand::ConstantOperand(ConstantRef::new(Constant::Int {
+                                bits: 32,
+                                value: idx.into(),
+                            }))
+                            .into()
+                        })
+                        .collect(),
+                ]
+                .concat(),
+                Instruction::InsertValue(insert_value) => [
+                    vec![insert_value.element.into()],
+                    insert_value
+                        .indices
+                        .into_iter()
+                        .map(|idx| {
+                            Operand::ConstantOperand(ConstantRef::new(Constant::Int {
+                                bits: 32,
+                                value: idx.into(),
+                            }))
+                            .into()
+                        })
+                        .collect(),
+                ]
+                .concat(),
+                Instruction::Alloca(alloca) => vec![
+                    /* TODO: handle type */
+                    alloca.num_elements.into(),
+                    /* TODO: handle alignment */
+                ],
+                Instruction::Load(load) => vec![
+                    load.address.into(),
+                    /* TODO: handle type */
+                    /* TODO: handle volatile */
+                    /* TODO: handle atomicity */
+                    /* TODO: handle alignment */
+                ],
+                Instruction::Store(store) => vec![
+                    store.address.into(),
+                    store.value.into(),
+                    /* TODO: handle volatile */
+                    /* TODO: handle atomicity */
+                    /* TODO: handle alignment */
+                ],
+                Instruction::Fence(_fence) => vec![/* TODO: handle atomicity */],
+                Instruction::CmpXchg(cmp_xchg) => vec![
+                    cmp_xchg.address.into(),
+                    cmp_xchg.expected.into(),
+                    cmp_xchg.replacement.into(),
+                    /* TODO: handle volatile */
+                    /* TODO: handle atomicity */
+                    /* TODO: handle memory ordering */
+                    /* TODO: handle weak */
+                ],
+                Instruction::AtomicRMW(atomic_rmw) => vec![
+                    atomic_rmw.operation.into(),
+                    atomic_rmw.address.into(),
+                    atomic_rmw.value.into(),
+                    /* TODO: handle volatile */
+                    /* TODO: handle atomicity */
+                ],
+                Instruction::GetElementPtr(get_element_ptr) => [
+                    vec![get_element_ptr.address.into()],
+                    get_element_ptr.indices.into_iter().map_into().collect(),
+                    /* TODO: handle in bounds */
+                    /* TODO: handle type */
+                ]
+                .concat(),
+                Instruction::Trunc(trunc) => vec![
+                    trunc.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::ZExt(zext) => vec![
+                    zext.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::SExt(sext) => vec![
+                    sext.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::FPTrunc(fptrunc) => vec![
+                    fptrunc.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::FPExt(fpext) => vec![
+                    fpext.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::FPToUI(fpto_ui) => vec![
+                    fpto_ui.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::FPToSI(fpto_si) => vec![
+                    fpto_si.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::UIToFP(uito_fp) => vec![
+                    uito_fp.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::SIToFP(sito_fp) => vec![
+                    sito_fp.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::PtrToInt(ptr_to_int) => vec![
+                    ptr_to_int.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::IntToPtr(int_to_ptr) => vec![
+                    int_to_ptr.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::BitCast(bit_cast) => vec![
+                    bit_cast.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::AddrSpaceCast(addr_space_cast) => vec![
+                    addr_space_cast.operand.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::ICmp(icmp) => vec![
+                    icmp.predicate.into(),
+                    icmp.operand0.into(),
+                    icmp.operand1.into(),
+                ],
+                Instruction::FCmp(fcmp) => vec![
+                    fcmp.predicate.into(),
+                    fcmp.operand0.into(),
+                    fcmp.operand1.into(),
+                ],
+                Instruction::Phi(phi) => phi
+                    .incoming_values
+                    .into_iter()
+                    .map(|(operand, _name)| operand.into())
+                    .collect(),
+                Instruction::Select(select) => vec![
+                    select.condition.into(),
+                    select.true_value.into(),
+                    select.false_value.into(),
+                ],
+                Instruction::Freeze(freeze) => vec![freeze.operand.into()],
+                Instruction::Call(call) => [
+                    vec![call.function.unwrap_right().into()],
+                    call.arguments
+                        .into_iter()
+                        .map(|(operand, _attr)| operand.into())
+                        .collect(),
+                    /* TODO: handle parameter attributes */
+                    /* TODO: handle function attributes */
+                    /* TODO: handle is_tail_call */
+                    /* TODO: handle calling convention */
+                ]
+                .concat(),
+                Instruction::VAArg(vaarg) => vec![
+                    vaarg.arg_list.into(),
+                    /* TODO: handle type */
+                ],
+                Instruction::LandingPad(_landing_pad) => {
+                    vec![
+                    /* TODO: handle type */
+                    /* TODO: handle clauses */
+                    /* TODO: handle cleanup */
+                    ]
+                }
+                Instruction::CatchPad(catch_pad) => [
+                    vec![catch_pad.catch_switch.into()],
+                    catch_pad.args.into_iter().map_into().collect(),
+                ]
+                .concat(),
+                Instruction::CleanupPad(cleanup_pad) => [
+                    vec![cleanup_pad.parent_pad.into()],
+                    cleanup_pad.args.into_iter().map_into().collect(),
+                ]
+                .concat(),
+            },
+        }
+    }
+}
+
+impl From<Operand> for Value {
+    fn from(value: Operand) -> Self {
+        match value {
+            Operand::LocalOperand { name, .. } => Value::Variable(name.into()),
+            Operand::ConstantOperand(c) => c.into(),
+            Operand::MetadataOperand => Value::Variable(Var::Metadata),
+        }
+    }
+}
+
+impl From<Either<InlineAssembly, Operand>> for Value {
+    fn from(value: Either<InlineAssembly, Operand>) -> Self {
+        match value {
+            Either::Left(inline_assembly) => inline_assembly.into(),
+            Either::Right(operand) => operand.into(),
+        }
+    }
+}
+
+pub fn parse(input: &str) -> Result<Expr, String> {
+    let module = llvm_ir::Module::from_ir_str(input)?;
+    debug!(
+        "Parsed LLVM IR module\n\
+            Name: {}\n\
+            Source filename: {}\n\
+            Target triple: {:?}\n\
+            Functions: {:#?}\n\
+            Function declarations: {:#?}\n\
+            Global variables: {:#?}\n\
+            Global aliases: {:#?}\n\
+            Global ifuncs: {:#?}\n\
+            Inline assembly: {}",
+        module.name,
+        module.source_file_name,
+        module.target_triple,
+        module.functions,
+        module.func_declarations,
+        module.global_vars,
+        module.global_aliases,
+        module.global_ifuncs,
+        module.inline_assembly,
+    );
+    Ok(module.into())
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::path::Path;
+
+    use dir_test::{Fixture, dir_test};
+
+    use super::{Expr, parse};
+
+    pub fn parse_llvm_ir(raw_path: &str) -> (&str, Expr) {
+        let path = Path::new(raw_path);
+        let program = std::fs::read_to_string(path).unwrap();
+        let expr = parse(&program).unwrap_or_else(|err| {
+            panic!(
+                "could not parse program {:?}\n{err:?}",
+                path.file_stem().unwrap()
+            )
+        });
+        let name = path.file_stem().unwrap().to_str().unwrap();
+        (name, expr)
+    }
+
+    #[dir_test(dir: "$CARGO_MANIFEST_DIR/../examples", glob: "**/*.ll", loader: crate::language::llvm_ir::tests::parse_llvm_ir, postfix: "check_parse")]
+    fn check_parse(fixture: Fixture<(&str, Expr)>) {
+        let (_name, _expr) = fixture.content();
+    }
+}

--- a/sd-core/src/language/mlir/mod.rs
+++ b/sd-core/src/language/mlir/mod.rs
@@ -34,6 +34,14 @@ impl Language for Mlir {
     type Symbol = Symbol;
 }
 
+impl TryFrom<<Mlir as super::Language>::Addr> for <Mlir as super::Language>::Symbol {
+    type Error = &'static str;
+
+    fn try_from(_: <Mlir as super::Language>::Addr) -> Result<Self, Self::Error> {
+        Err("no function addresses in mlir")
+    }
+}
+
 pub type Expr = super::Expr<Mlir>;
 pub type Bind = super::Bind<Mlir>;
 pub type Value = super::Value<Mlir>;

--- a/sd-core/src/language/mod.rs
+++ b/sd-core/src/language/mod.rs
@@ -8,6 +8,7 @@ use derivative::Derivative;
 use crate::{common::Matchable, hypergraph::traits::WithType, prettyprinter::PrettyPrint};
 
 pub mod chil;
+pub mod llvm_ir;
 pub mod mlir;
 pub mod spartan;
 
@@ -65,7 +66,7 @@ pub trait Language {
     type Addr: Syntax;
     type BlockAddr: Syntax;
     type VarDef: Syntax + GetVar<Self::Var>;
-    type Symbol: Syntax;
+    type Symbol: Syntax + TryFrom<Self::Addr, Error: Debug>;
 }
 
 #[derive(Derivative)]
@@ -236,13 +237,14 @@ pub(crate) mod tests {
     use super::{
         Expr, Language,
         chil::tests::parse_chil,
+        llvm_ir::tests::parse_llvm_ir,
         mlir::{
             self,
             internal::{TopLevelItem, tests::parse_mlir},
         },
         spartan::tests::parse_sd,
     };
-    use crate::{graph::SyntaxHypergraph, hypergraph::petgraph::to_pet};
+    use crate::{graph::SyntaxHypergraph, hypergraph::petgraph::to_pet, language::llvm_ir::LlvmIr};
 
     pub trait ExprTest {
         fn free_var_test(&self) -> Box<dyn std::fmt::Debug>;
@@ -272,6 +274,24 @@ pub(crate) mod tests {
         }
     }
 
+    impl ExprTest for crate::language::llvm_ir::Expr {
+        fn free_var_test(&self) -> Box<dyn std::fmt::Debug> {
+            Box::new(self.free_vars(false))
+        }
+
+        fn graph_test(&self, name: &str, lang: &str, sym_name_link: bool) -> anyhow::Result<()> {
+            let graph: SyntaxHypergraph<LlvmIr> = self.to_graph(sym_name_link)?;
+            let name = if sym_name_link {
+                format!("hypergraph_with_sym_{name}_debug.{lang}")
+            } else {
+                format!("hypergraph_{name}_debug.{lang}")
+            };
+            // cannot serialise LLVM IR expressions, so use Debug instead
+            insta::assert_debug_snapshot!(name, to_pet(&graph));
+            Ok(())
+        }
+    }
+
     pub fn parse(raw_path: &str) -> (&str, &str, Box<dyn ExprTest>) {
         let path = Path::new(raw_path);
         match path.extension() {
@@ -282,6 +302,10 @@ pub(crate) mod tests {
             Some(ext) if ext == OsStr::new("chil") => {
                 let (name, expr) = parse_chil(raw_path);
                 ("chil", name, Box::new(expr))
+            }
+            Some(ext) if ext == OsStr::new("ll") => {
+                let (name, expr) = parse_llvm_ir(raw_path);
+                ("llvm-ir", name, Box::new(expr))
             }
             Some(ext) if ext == OsStr::new("mlir") => {
                 let (name, items) = parse_mlir(raw_path);

--- a/sd-core/src/language/mod.rs
+++ b/sd-core/src/language/mod.rs
@@ -8,6 +8,7 @@ use derivative::Derivative;
 use crate::{common::Matchable, hypergraph::traits::WithType, prettyprinter::PrettyPrint};
 
 pub mod chil;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod llvm_ir;
 pub mod mlir;
 pub mod spartan;

--- a/sd-core/src/language/snapshots/sd_core__language__llvm_ir__tests__parse_llvm_ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__llvm_ir__tests__parse_llvm_ir.snap
@@ -1,0 +1,130 @@
+---
+source: sd-core/src/language/llvm_ir.rs
+expression: expr
+---
+Expr {
+    binds: [
+        Bind {
+            defs: [
+                Name(
+                    "add1",
+                ),
+            ],
+            value: Thunk(
+                Thunk {
+                    addr: "add1",
+                    args: [
+                        Name(
+                            "a",
+                        ),
+                        Name(
+                            "b",
+                        ),
+                    ],
+                    body: Expr {
+                        binds: [],
+                        values: [],
+                    },
+                    blocks: [
+                        Block {
+                            addr: Name(
+                                "entry",
+                            ),
+                            args: [],
+                            expr: Expr {
+                                binds: [
+                                    Bind {
+                                        defs: [
+                                            Name(
+                                                "tmp1",
+                                            ),
+                                        ],
+                                        value: Op {
+                                            op: Instruction(
+                                                Add(
+                                                    Add {
+                                                        operand0: LocalOperand {
+                                                            name: Name(
+                                                                "a",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        operand1: LocalOperand {
+                                                            name: Name(
+                                                                "b",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        dest: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        nuw: false,
+                                                        nsw: false,
+                                                        debugloc: None,
+                                                    },
+                                                ),
+                                            ),
+                                            args: [
+                                                Variable(
+                                                    Name(
+                                                        "a",
+                                                    ),
+                                                ),
+                                                Variable(
+                                                    Name(
+                                                        "b",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                    Bind {
+                                        defs: [],
+                                        value: Op {
+                                            op: Terminator(
+                                                Ret(
+                                                    Ret {
+                                                        return_operand: Some(
+                                                            LocalOperand {
+                                                                name: Name(
+                                                                    "tmp1",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    IntegerType {
+                                                                        bits: 32,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        debugloc: None,
+                                                    },
+                                                ),
+                                            ),
+                                            args: [
+                                                Variable(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ],
+                                values: [],
+                            },
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+    values: [],
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_add_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_add_debug.llvm-ir.snap
@@ -1,0 +1,730 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 2,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 9,
+                edge_count: 10,
+                edges: (1, 2), (3, 2), (2, 4), (1, 5), (0, 5), (6, 5), (5, 7), (0, 8), (8, 3), (8, 6),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "a",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "b",
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 3,
+                            edge_count: 2,
+                            edges: (0, 1), (1, 2),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "b",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "b",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        CF(
+                            Some(
+                                Name(
+                                    "done",
+                                ),
+                            ),
+                        ),
+                    ),
+                    4: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    5: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 16,
+                            edge_count: 15,
+                            edges: (3, 2), (2, 4), (6, 5), (7, 5), (8, 5), (5, 3), (9, 6), (0, 10), (11, 10), (10, 8), (12, 11), (1, 13), (14, 13), (13, 7), (15, 14),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "b",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "a",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp4",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp4",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "add2",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        LocalOperand {
+                                                            name: Name(
+                                                                "tmp2",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Name(
+                                                                "tmp3",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp4",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp2",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp3",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "add2",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "b",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "tmp3",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    Nil,
+                                ),
+                                12: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Operation(
+                                    Instruction(
+                                        Sub(
+                                            Sub {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "a",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "tmp2",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 2,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 1,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                            },
+                        },
+                    ),
+                    6: Edge(
+                        CF(
+                            Some(
+                                Name(
+                                    "recurse",
+                                ),
+                            ),
+                        ),
+                    ),
+                    7: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    8: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 10,
+                            edge_count: 9,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (0, 5), (7, 5), (5, 2), (8, 7), (9, 6),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "a",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Name(
+                                                        "tmp1",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Name(
+                                                    "done",
+                                                ),
+                                                false_dest: Name(
+                                                    "recurse",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Name(
+                                                "done",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Name(
+                                                "recurse",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "a",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "tmp1",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                    3: 0,
+                    4: 1,
+                    5: 2,
+                    6: 0,
+                    7: 0,
+                    8: 0,
+                    9: 1,
+                },
+            },
+        ),
+        1: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 4,
+                edge_count: 3,
+                edges: (0, 2), (1, 2), (2, 3),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "a",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "b",
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 5,
+                            edges: (3, 2), (2, 4), (0, 5), (1, 5), (5, 3),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "a",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "b",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "a",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Name(
+                                                        "b",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Name(
+                                                    "tmp1",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_alias_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_alias_debug.llvm-ir.snap
@@ -1,0 +1,283 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 4,
+    edge_count: 2,
+    edges: (1, 0), (2, 1),
+    node weights: {
+        0: Operation(
+            GlobalAlias(
+                GlobalAlias {
+                    name: Name(
+                        "alias_func",
+                    ),
+                    aliasee: ConstantRef(
+                        GlobalReference {
+                            name: Name(
+                                "some_function",
+                            ),
+                            ty: TypeRef(
+                                FuncType {
+                                    result_type: TypeRef(
+                                        IntegerType {
+                                            bits: 32,
+                                        },
+                                    ),
+                                    param_types: [
+                                        TypeRef(
+                                            IntegerType {
+                                                bits: 32,
+                                            },
+                                        ),
+                                    ],
+                                    is_var_arg: false,
+                                },
+                            ),
+                        },
+                    ),
+                    linkage: External,
+                    visibility: Default,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    addr_space: 0,
+                    dll_storage_class: Default,
+                    thread_local_mode: NotThreadLocal,
+                    unnamed_addr: None,
+                },
+            ),
+        ),
+        1: Edge(
+            Nil,
+        ),
+        2: Operation(
+            Constant(
+                ConstantRef(
+                    GlobalReference {
+                        name: Name(
+                            "some_function",
+                        ),
+                        ty: TypeRef(
+                            FuncType {
+                                result_type: TypeRef(
+                                    IntegerType {
+                                        bits: 32,
+                                    },
+                                ),
+                                param_types: [
+                                    TypeRef(
+                                        IntegerType {
+                                            bits: 32,
+                                        },
+                                    ),
+                                ],
+                                is_var_arg: false,
+                            },
+                        ),
+                    },
+                ),
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 8,
+                            edge_count: 7,
+                            edges: (1, 0), (0, 2), (4, 3), (5, 3), (3, 1), (6, 5), (7, 4),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "alias_func",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 42,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "result",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 42,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "alias_func",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_diverge_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_diverge_debug.llvm-ir.snap
@@ -1,0 +1,159 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 1,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 5,
+                            edges: (1, 0), (0, 2), (4, 3), (3, 1), (5, 4),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "diverge",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "diverge",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_fact_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_fact_debug.llvm-ir.snap
@@ -1,0 +1,994 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 1,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 12,
+                edge_count: 16,
+                edges: (2, 1), (3, 1), (4, 1), (1, 5), (2, 6), (7, 6), (8, 6), (6, 4), (2, 9), (10, 9), (9, 3), (0, 11), (11, 10), (11, 8), (11, 7), (11, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 5,
+                            edge_count: 4,
+                            edges: (2, 1), (1, 3), (0, 4), (4, 2),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            14,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    2,
+                                ),
+                            },
+                        ),
+                    ),
+                    3: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    13,
+                                ),
+                            ),
+                        ),
+                    ),
+                    4: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    13,
+                                ),
+                            ),
+                        ),
+                    ),
+                    5: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    6: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 19,
+                            edge_count: 18,
+                            edges: (2, 3), (0, 4), (5, 4), (7, 6), (8, 6), (6, 5), (10, 9), (11, 9), (9, 8), (12, 10), (14, 13), (15, 13), (13, 11), (16, 15), (1, 17), (17, 14), (1, 18), (18, 7),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                13,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        Mul(
+                                            Mul {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "fact",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                10,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NoUndef,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Number(
+                                                        11,
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Edge(
+                                    Nil,
+                                ),
+                                11: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                12: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "fact",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Operation(
+                                    Instruction(
+                                        Sub(
+                                            Sub {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 0,
+                                6: 0,
+                                7: 1,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 1,
+                                12: 0,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                            },
+                        },
+                    ),
+                    7: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    3,
+                                ),
+                            },
+                        ),
+                    ),
+                    8: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    7,
+                                ),
+                            ),
+                        ),
+                    ),
+                    9: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 4,
+                            edges: (1, 2), (0, 3), (4, 3), (5, 4),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                13,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                            },
+                        },
+                    ),
+                    10: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    6,
+                                ),
+                            ),
+                        ),
+                    ),
+                    11: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 21,
+                            edge_count: 19,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (7, 5), (8, 5), (5, 2), (9, 8), (10, 6), (12, 11), (11, 7), (12, 13), (0, 13), (15, 14), (14, 12), (16, 15), (18, 17), (17, 19), (20, 18),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    6,
+                                                ),
+                                                false_dest: Number(
+                                                    7,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                6,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                7,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                13: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Edge(
+                                    Nil,
+                                ),
+                                19: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                20: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 0,
+                    4: 0,
+                    5: 1,
+                    6: 2,
+                    7: 0,
+                    8: 0,
+                    9: 1,
+                    10: 0,
+                    11: 0,
+                    12: 0,
+                    13: 1,
+                    14: 2,
+                    15: 3,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_hello_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_hello_debug.llvm-ir.snap
@@ -1,0 +1,82 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 1,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 4,
+                            edge_count: 3,
+                            edges: (1, 0), (0, 2), (3, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    Nil,
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_ifunc_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_ifunc_debug.llvm-ir.snap
@@ -1,0 +1,825 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 7,
+    edge_count: 2,
+    edges: (1, 0), (2, 1),
+    node weights: {
+        0: Operation(
+            GlobalIFunc(
+                GlobalIFunc {
+                    name: Name(
+                        "indirect_func",
+                    ),
+                    linkage: External,
+                    visibility: Default,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    resolver_fn: ConstantRef(
+                        GlobalReference {
+                            name: Name(
+                                "resolver",
+                            ),
+                            ty: TypeRef(
+                                FuncType {
+                                    result_type: TypeRef(
+                                        PointerType {
+                                            addr_space: 0,
+                                        },
+                                    ),
+                                    param_types: [],
+                                    is_var_arg: false,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ),
+        1: Edge(
+            Nil,
+        ),
+        2: Operation(
+            Constant(
+                ConstantRef(
+                    GlobalReference {
+                        name: Name(
+                            "resolver",
+                        ),
+                        ty: TypeRef(
+                            FuncType {
+                                result_type: TypeRef(
+                                    PointerType {
+                                        addr_space: 0,
+                                    },
+                                ),
+                                param_types: [],
+                                is_var_arg: false,
+                            },
+                        ),
+                    },
+                ),
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 8,
+                            edge_count: 7,
+                            edges: (1, 0), (0, 2), (4, 3), (5, 3), (3, 1), (6, 5), (7, 4),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "indirect_func",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 5,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "result",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "indirect_func",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+        4: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 16,
+                            edge_count: 15,
+                            edges: (1, 0), (0, 2), (4, 3), (5, 3), (6, 3), (3, 1), (7, 6), (8, 5), (10, 9), (11, 9), (12, 9), (9, 4), (13, 12), (14, 11), (15, 10),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "func",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            PointerType {
+                                                                addr_space: 0,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "func",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Select(
+                                            Select {
+                                                condition: LocalOperand {
+                                                    name: Name(
+                                                        "cond",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_value: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "impl_fast",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                FuncType {
+                                                                    result_type: TypeRef(
+                                                                        IntegerType {
+                                                                            bits: 32,
+                                                                        },
+                                                                    ),
+                                                                    param_types: [
+                                                                        TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    is_var_arg: false,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                false_value: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "impl_slow",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                FuncType {
+                                                                    result_type: TypeRef(
+                                                                        IntegerType {
+                                                                            bits: 32,
+                                                                        },
+                                                                    ),
+                                                                    param_types: [
+                                                                        TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    is_var_arg: false,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "func",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "cond",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "impl_slow",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "impl_fast",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "cond",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Edge(
+                                    Nil,
+                                ),
+                                11: Edge(
+                                    Nil,
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 2,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 1,
+                                10: 2,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+        5: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "x",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (0, 4), (5, 4), (4, 2), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "x",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Mul(
+                                            Mul {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "x",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "result",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        6: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "x",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (0, 4), (5, 4), (4, 2), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "x",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Shl(
+                                            Shl {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "x",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "result",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_jump_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_jump_debug.llvm-ir.snap
@@ -1,0 +1,112 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 1,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 5,
+                edge_count: 3,
+                edges: (2, 1), (1, 3), (4, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "a",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: None,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            Some(
+                                Name(
+                                    "done",
+                                ),
+                            ),
+                        ),
+                    ),
+                    3: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    4: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Name(
+                                                    "done",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Name(
+                                                "done",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                    2: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_linkedlist_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_linkedlist_debug.llvm-ir.snap
@@ -1,0 +1,7431 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 3,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 18,
+                            edge_count: 17,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (7, 6), (8, 6), (9, 6), (6, 5), (10, 9), (11, 7), (13, 12), (12, 8), (13, 14), (0, 14), (16, 15), (15, 13), (17, 16),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            5,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        ZExt(
+                                            ZExt {
+                                                operand: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: NE,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    IntPredicate(
+                                        NE,
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 1,
+                                6: 2,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        1: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 167,
+                            edge_count: 169,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (7, 6), (8, 6), (9, 6), (6, 5), (10, 9), (11, 8), (13, 12), (12, 7), (15, 14), (16, 14), (17, 14), (14, 13), (18, 17), (19, 16), (21, 20), (20, 15), (23, 22), (24, 22), (25, 22), (22, 21), (26, 25), (27, 24), (29, 28), (28, 23), (31, 30), (32, 30), (33, 30), (30, 29), (34, 33), (35, 32), (37, 36), (36, 31), (39, 38), (40, 38), (41, 38), (38, 37), (42, 41), (43, 40), (45, 44), (44, 39), (47, 46), (48, 46), (49, 46), (46, 45), (50, 49), (51, 48), (53, 52), (52, 47), (55, 54), (56, 54), (57, 54), (54, 53), (58, 57), (59, 56), (61, 60), (60, 55), (63, 62), (64, 62), (65, 62), (62, 61), (66, 65), (67, 64), (69, 68), (70, 68), (72, 71), (73, 71), (74, 71), (71, 69), (75, 74), (76, 73), (78, 77), (72, 77), (70, 79), (80, 79), (81, 79), (79, 78), (82, 81), (83, 80), (85, 84), (70, 84), (63, 86), (87, 86), (88, 86), (86, 85), (89, 88), (90, 87), (92, 91), (93, 91), (94, 93), (72, 95), (96, 95), (97, 95), (95, 92), (98, 97), (99, 96), (101, 100), (102, 100), (104, 103), (105, 103), (103, 102), (106, 105), (108, 107), (107, 104), (72, 109), (110, 109), (111, 109), (109, 101), (112, 111), (113, 110), (115, 114), (116, 114), (117, 116), (70, 118), (119, 118), (120, 118), (118, 115), (121, 120), (122, 119), (124, 123), (125, 123), (127, 126), (128, 126), (126, 125), (129, 128), (108, 130), (130, 127), (70, 131), (132, 131), (133, 131), (131, 124), (134, 133), (135, 132), (137, 136), (138, 136), (139, 138), (63, 140), (141, 140), (142, 140), (140, 137), (143, 142), (144, 141), (146, 145), (147, 145), (108, 148), (148, 147), (63, 149), (150, 149), (151, 149), (149, 146), (152, 151), (153, 150), (108, 154), (0, 154), (156, 155), (155, 72), (157, 156), (159, 158), (158, 70), (160, 159), (162, 161), (161, 63), (163, 162), (165, 164), (164, 108), (166, 165),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            35,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                35,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        34,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    35,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                34,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        33,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    34,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        32,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    33,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                32,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        31,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    32,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                31,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        30,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    31,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                30,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                22: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        29,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    30,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                24: Edge(
+                                    Nil,
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                27: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        28,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    29,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                28,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                30: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        27,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    28,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                27,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Edge(
+                                    Nil,
+                                ),
+                                33: Edge(
+                                    Nil,
+                                ),
+                                34: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                35: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                36: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    27,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                37: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                26,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                38: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        25,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    26,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                39: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                25,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                40: Edge(
+                                    Nil,
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                43: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        24,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    25,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                45: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                24,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                46: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        23,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    24,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                47: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                23,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Edge(
+                                    Nil,
+                                ),
+                                50: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                51: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                52: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        22,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    23,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                53: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                22,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                54: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    22,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                21,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                56: Edge(
+                                    Nil,
+                                ),
+                                57: Edge(
+                                    Nil,
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        20,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    21,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                20,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                62: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    20,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                63: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                64: Edge(
+                                    Nil,
+                                ),
+                                65: Edge(
+                                    Nil,
+                                ),
+                                66: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                67: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                68: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        19,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                69: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                19,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                70: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                71: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    19,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                72: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                73: Edge(
+                                    Nil,
+                                ),
+                                74: Edge(
+                                    Nil,
+                                ),
+                                75: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                76: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                77: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        18,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                78: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                18,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                79: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    18,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                80: Edge(
+                                    Nil,
+                                ),
+                                81: Edge(
+                                    Nil,
+                                ),
+                                82: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                83: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                84: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                85: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                17,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                86: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    17,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                87: Edge(
+                                    Nil,
+                                ),
+                                88: Edge(
+                                    Nil,
+                                ),
+                                89: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                90: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                91: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        16,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                92: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                16,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                93: Edge(
+                                    Nil,
+                                ),
+                                94: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                95: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    16,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                96: Edge(
+                                    Nil,
+                                ),
+                                97: Edge(
+                                    Nil,
+                                ),
+                                98: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                99: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                100: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                101: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                102: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                103: Operation(
+                                    Instruction(
+                                        SDiv(
+                                            SDiv {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        14,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 4,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                exact: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                104: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                105: Edge(
+                                    Nil,
+                                ),
+                                106: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                107: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                108: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                109: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                110: Edge(
+                                    Nil,
+                                ),
+                                111: Edge(
+                                    Nil,
+                                ),
+                                112: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                113: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                114: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                115: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                116: Edge(
+                                    Nil,
+                                ),
+                                117: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                118: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                119: Edge(
+                                    Nil,
+                                ),
+                                120: Edge(
+                                    Nil,
+                                ),
+                                121: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                122: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                123: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                124: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                125: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                126: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 3,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                127: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                128: Edge(
+                                    Nil,
+                                ),
+                                129: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                130: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                131: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                132: Edge(
+                                    Nil,
+                                ),
+                                133: Edge(
+                                    Nil,
+                                ),
+                                134: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                135: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                136: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                137: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                138: Edge(
+                                    Nil,
+                                ),
+                                139: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                140: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                141: Edge(
+                                    Nil,
+                                ),
+                                142: Edge(
+                                    Nil,
+                                ),
+                                143: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                144: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                145: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                146: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                6,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                147: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                148: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                149: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    6,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                150: Edge(
+                                    Nil,
+                                ),
+                                151: Edge(
+                                    Nil,
+                                ),
+                                152: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                153: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                154: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                155: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                156: Edge(
+                                    Nil,
+                                ),
+                                157: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                158: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                159: Edge(
+                                    Nil,
+                                ),
+                                160: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                161: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                162: Edge(
+                                    Nil,
+                                ),
+                                163: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                164: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                165: Edge(
+                                    Nil,
+                                ),
+                                166: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 1,
+                                6: 2,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 2,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 1,
+                                22: 2,
+                                23: 0,
+                                24: 0,
+                                25: 0,
+                                26: 0,
+                                27: 0,
+                                28: 0,
+                                29: 1,
+                                30: 2,
+                                31: 0,
+                                32: 0,
+                                33: 0,
+                                34: 0,
+                                35: 0,
+                                36: 0,
+                                37: 1,
+                                38: 2,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 0,
+                                44: 0,
+                                45: 1,
+                                46: 2,
+                                47: 0,
+                                48: 0,
+                                49: 0,
+                                50: 0,
+                                51: 0,
+                                52: 0,
+                                53: 1,
+                                54: 2,
+                                55: 0,
+                                56: 0,
+                                57: 0,
+                                58: 0,
+                                59: 0,
+                                60: 0,
+                                61: 1,
+                                62: 2,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 1,
+                                68: 0,
+                                69: 1,
+                                70: 2,
+                                71: 0,
+                                72: 0,
+                                73: 0,
+                                74: 0,
+                                75: 1,
+                                76: 0,
+                                77: 1,
+                                78: 2,
+                                79: 0,
+                                80: 0,
+                                81: 0,
+                                82: 0,
+                                83: 1,
+                                84: 0,
+                                85: 1,
+                                86: 2,
+                                87: 0,
+                                88: 0,
+                                89: 0,
+                                90: 0,
+                                91: 1,
+                                92: 0,
+                                93: 0,
+                                94: 1,
+                                95: 2,
+                                96: 0,
+                                97: 0,
+                                98: 0,
+                                99: 0,
+                                100: 1,
+                                101: 0,
+                                102: 1,
+                                103: 0,
+                                104: 0,
+                                105: 0,
+                                106: 0,
+                                107: 0,
+                                108: 1,
+                                109: 2,
+                                110: 0,
+                                111: 0,
+                                112: 0,
+                                113: 0,
+                                114: 1,
+                                115: 0,
+                                116: 0,
+                                117: 1,
+                                118: 2,
+                                119: 0,
+                                120: 0,
+                                121: 0,
+                                122: 0,
+                                123: 1,
+                                124: 0,
+                                125: 1,
+                                126: 0,
+                                127: 0,
+                                128: 0,
+                                129: 0,
+                                130: 0,
+                                131: 1,
+                                132: 2,
+                                133: 0,
+                                134: 0,
+                                135: 0,
+                                136: 0,
+                                137: 1,
+                                138: 0,
+                                139: 0,
+                                140: 1,
+                                141: 2,
+                                142: 0,
+                                143: 0,
+                                144: 0,
+                                145: 0,
+                                146: 1,
+                                147: 0,
+                                148: 0,
+                                149: 0,
+                                150: 1,
+                                151: 2,
+                                152: 0,
+                                153: 0,
+                                154: 0,
+                                155: 0,
+                                156: 1,
+                                157: 0,
+                                158: 0,
+                                159: 0,
+                                160: 0,
+                                161: 0,
+                                162: 0,
+                                163: 0,
+                                164: 0,
+                                165: 0,
+                                166: 0,
+                                167: 0,
+                                168: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        2: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 270,
+                            edge_count: 275,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (7, 6), (8, 6), (9, 6), (6, 5), (10, 9), (11, 8), (13, 12), (12, 7), (15, 14), (16, 14), (17, 14), (14, 13), (18, 17), (19, 16), (21, 20), (20, 15), (23, 22), (24, 22), (25, 22), (22, 21), (26, 25), (27, 24), (29, 28), (28, 23), (31, 30), (32, 30), (33, 30), (30, 29), (34, 33), (35, 32), (37, 36), (36, 31), (39, 38), (40, 38), (41, 38), (38, 37), (42, 41), (43, 40), (45, 44), (44, 39), (47, 46), (48, 46), (49, 46), (46, 45), (50, 49), (51, 48), (53, 52), (52, 47), (55, 54), (56, 54), (57, 54), (54, 53), (58, 57), (59, 56), (61, 60), (60, 55), (63, 62), (64, 62), (65, 62), (62, 61), (66, 65), (67, 64), (69, 68), (68, 63), (71, 70), (72, 70), (73, 70), (70, 69), (74, 73), (75, 72), (77, 76), (76, 71), (79, 78), (80, 78), (81, 78), (78, 77), (82, 81), (83, 80), (85, 84), (84, 79), (87, 86), (88, 86), (89, 86), (86, 85), (90, 89), (91, 88), (93, 92), (87, 92), (95, 94), (96, 94), (97, 94), (94, 93), (98, 97), (99, 96), (101, 100), (95, 100), (103, 102), (104, 102), (105, 102), (102, 101), (106, 105), (107, 104), (109, 108), (103, 108), (111, 110), (112, 110), (113, 110), (110, 109), (114, 113), (115, 112), (117, 116), (111, 116), (119, 118), (120, 118), (121, 118), (118, 117), (122, 121), (123, 120), (125, 124), (119, 124), (87, 126), (127, 126), (128, 126), (126, 125), (129, 128), (130, 127), (132, 131), (133, 131), (134, 133), (95, 135), (136, 135), (137, 135), (135, 132), (138, 137), (139, 136), (141, 140), (142, 140), (144, 143), (145, 143), (143, 142), (146, 145), (148, 147), (147, 144), (95, 149), (150, 149), (151, 149), (149, 141), (152, 151), (153, 150), (155, 154), (156, 154), (157, 156), (103, 158), (159, 158), (160, 158), (158, 155), (161, 160), (162, 159), (164, 163), (165, 163), (167, 166), (168, 166), (166, 165), (169, 168), (148, 170), (170, 167), (103, 171), (172, 171), (173, 171), (171, 164), (174, 173), (175, 172), (177, 176), (178, 176), (179, 178), (111, 180), (181, 180), (182, 180), (180, 177), (183, 182), (184, 181), (186, 185), (187, 185), (189, 188), (190, 188), (188, 187), (191, 190), (148, 192), (192, 189), (111, 193), (194, 193), (195, 193), (193, 186), (196, 195), (197, 194), (199, 198), (200, 198), (201, 200), (119, 202), (203, 202), (204, 202), (202, 199), (205, 204), (206, 203), (208, 207), (209, 207), (211, 210), (212, 210), (210, 209), (213, 212), (148, 214), (214, 211), (119, 215), (216, 215), (217, 215), (215, 208), (218, 217), (219, 216), (221, 220), (222, 220), (224, 223), (225, 223), (223, 222), (226, 225), (221, 227), (227, 224), (87, 228), (229, 228), (230, 228), (228, 221), (231, 230), (232, 229), (234, 233), (235, 233), (236, 235), (87, 237), (238, 237), (239, 237), (237, 234), (240, 239), (241, 238), (243, 242), (244, 242), (148, 245), (245, 244), (87, 246), (247, 246), (248, 246), (246, 243), (249, 248), (250, 247), (148, 251), (0, 251), (253, 252), (252, 95), (254, 253), (256, 255), (255, 103), (257, 256), (259, 258), (258, 111), (260, 259), (262, 261), (261, 119), (263, 262), (265, 264), (264, 87), (266, 265), (268, 267), (267, 148), (269, 268),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            56,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                56,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        55,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    56,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                55,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        54,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    55,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                54,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        53,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    54,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                53,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        52,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    53,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                52,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        51,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    52,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                51,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                22: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        50,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    51,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                50,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                24: Edge(
+                                    Nil,
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                27: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        49,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    50,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                49,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                30: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        48,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    49,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                48,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Edge(
+                                    Nil,
+                                ),
+                                33: Edge(
+                                    Nil,
+                                ),
+                                34: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                35: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                36: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        47,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    48,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                37: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                47,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                38: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        46,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    47,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                39: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                46,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                40: Edge(
+                                    Nil,
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                43: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        45,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    46,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                45: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                45,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                46: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        44,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    45,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                47: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                44,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Edge(
+                                    Nil,
+                                ),
+                                50: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                51: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                52: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        43,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    44,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                53: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                43,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                54: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        42,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    43,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                42,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                56: Edge(
+                                    Nil,
+                                ),
+                                57: Edge(
+                                    Nil,
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        41,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    42,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                41,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                62: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        40,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    41,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                63: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                40,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                64: Edge(
+                                    Nil,
+                                ),
+                                65: Edge(
+                                    Nil,
+                                ),
+                                66: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                67: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                68: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        39,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    40,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                69: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                39,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                70: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        38,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    39,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                71: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                38,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                72: Edge(
+                                    Nil,
+                                ),
+                                73: Edge(
+                                    Nil,
+                                ),
+                                74: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                75: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                76: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        37,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    38,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                77: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                37,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                78: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        36,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    37,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                79: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                36,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                80: Edge(
+                                    Nil,
+                                ),
+                                81: Edge(
+                                    Nil,
+                                ),
+                                82: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                83: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                84: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        35,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    36,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                85: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                35,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                86: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    35,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                87: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                88: Edge(
+                                    Nil,
+                                ),
+                                89: Edge(
+                                    Nil,
+                                ),
+                                90: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                91: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                92: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        34,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                93: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                34,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                94: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    34,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                95: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                96: Edge(
+                                    Nil,
+                                ),
+                                97: Edge(
+                                    Nil,
+                                ),
+                                98: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                99: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                100: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        33,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                101: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                102: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    33,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                103: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                6,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                104: Edge(
+                                    Nil,
+                                ),
+                                105: Edge(
+                                    Nil,
+                                ),
+                                106: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                107: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                108: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        32,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                109: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                32,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                110: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    32,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                111: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                112: Edge(
+                                    Nil,
+                                ),
+                                113: Edge(
+                                    Nil,
+                                ),
+                                114: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                115: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                116: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        31,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                117: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                31,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                118: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    31,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                119: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                120: Edge(
+                                    Nil,
+                                ),
+                                121: Edge(
+                                    Nil,
+                                ),
+                                122: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                123: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                124: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        30,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                125: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                30,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                126: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    30,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                127: Edge(
+                                    Nil,
+                                ),
+                                128: Edge(
+                                    Nil,
+                                ),
+                                129: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                130: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                131: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        29,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                132: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                133: Edge(
+                                    Nil,
+                                ),
+                                134: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                135: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    29,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                136: Edge(
+                                    Nil,
+                                ),
+                                137: Edge(
+                                    Nil,
+                                ),
+                                138: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                139: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                140: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        28,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                141: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                26,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                142: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                28,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                143: Operation(
+                                    Instruction(
+                                        SDiv(
+                                            SDiv {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        27,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 100,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    28,
+                                                ),
+                                                exact: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                144: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                27,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                145: Edge(
+                                    Nil,
+                                ),
+                                146: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 100,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                147: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    27,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                148: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                149: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    26,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                150: Edge(
+                                    Nil,
+                                ),
+                                151: Edge(
+                                    Nil,
+                                ),
+                                152: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                153: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                154: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        25,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                155: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                25,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                156: Edge(
+                                    Nil,
+                                ),
+                                157: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                158: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    25,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                159: Edge(
+                                    Nil,
+                                ),
+                                160: Edge(
+                                    Nil,
+                                ),
+                                161: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                162: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                163: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        22,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        24,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                164: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                22,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                165: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                24,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                166: Operation(
+                                    Instruction(
+                                        SDiv(
+                                            SDiv {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        23,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    24,
+                                                ),
+                                                exact: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                167: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                23,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                168: Edge(
+                                    Nil,
+                                ),
+                                169: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                170: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    23,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                171: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    22,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                172: Edge(
+                                    Nil,
+                                ),
+                                173: Edge(
+                                    Nil,
+                                ),
+                                174: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                175: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                176: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                177: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                21,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                178: Edge(
+                                    Nil,
+                                ),
+                                179: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                180: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    21,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                181: Edge(
+                                    Nil,
+                                ),
+                                182: Edge(
+                                    Nil,
+                                ),
+                                183: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                184: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                185: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        18,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        20,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                186: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                18,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                187: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                20,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                188: Operation(
+                                    Instruction(
+                                        Mul(
+                                            Mul {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        19,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    20,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                189: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                19,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                190: Edge(
+                                    Nil,
+                                ),
+                                191: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                192: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    19,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                193: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    18,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                194: Edge(
+                                    Nil,
+                                ),
+                                195: Edge(
+                                    Nil,
+                                ),
+                                196: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                197: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                198: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                199: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                17,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                200: Edge(
+                                    Nil,
+                                ),
+                                201: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                202: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    17,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                203: Edge(
+                                    Nil,
+                                ),
+                                204: Edge(
+                                    Nil,
+                                ),
+                                205: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                206: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                207: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        14,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        16,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                208: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                209: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                16,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                210: Operation(
+                                    Instruction(
+                                        Sub(
+                                            Sub {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 3,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    16,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                211: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                212: Edge(
+                                    Nil,
+                                ),
+                                213: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                214: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                215: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                216: Edge(
+                                    Nil,
+                                ),
+                                217: Edge(
+                                    Nil,
+                                ),
+                                218: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                219: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                220: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                221: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                222: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                223: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                224: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                225: Edge(
+                                    Nil,
+                                ),
+                                226: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                227: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                228: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                229: Edge(
+                                    Nil,
+                                ),
+                                230: Edge(
+                                    Nil,
+                                ),
+                                231: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                232: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                233: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                234: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                235: Edge(
+                                    Nil,
+                                ),
+                                236: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                237: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                238: Edge(
+                                    Nil,
+                                ),
+                                239: Edge(
+                                    Nil,
+                                ),
+                                240: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                241: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                242: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                243: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                244: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                245: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                246: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                247: Edge(
+                                    Nil,
+                                ),
+                                248: Edge(
+                                    Nil,
+                                ),
+                                249: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                250: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                251: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                252: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                253: Edge(
+                                    Nil,
+                                ),
+                                254: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                255: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    6,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                256: Edge(
+                                    Nil,
+                                ),
+                                257: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                258: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                259: Edge(
+                                    Nil,
+                                ),
+                                260: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                261: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                262: Edge(
+                                    Nil,
+                                ),
+                                263: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                264: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                265: Edge(
+                                    Nil,
+                                ),
+                                266: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                267: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                268: Edge(
+                                    Nil,
+                                ),
+                                269: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 1,
+                                6: 2,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 2,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 1,
+                                22: 2,
+                                23: 0,
+                                24: 0,
+                                25: 0,
+                                26: 0,
+                                27: 0,
+                                28: 0,
+                                29: 1,
+                                30: 2,
+                                31: 0,
+                                32: 0,
+                                33: 0,
+                                34: 0,
+                                35: 0,
+                                36: 0,
+                                37: 1,
+                                38: 2,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 0,
+                                44: 0,
+                                45: 1,
+                                46: 2,
+                                47: 0,
+                                48: 0,
+                                49: 0,
+                                50: 0,
+                                51: 0,
+                                52: 0,
+                                53: 1,
+                                54: 2,
+                                55: 0,
+                                56: 0,
+                                57: 0,
+                                58: 0,
+                                59: 0,
+                                60: 0,
+                                61: 1,
+                                62: 2,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 0,
+                                68: 0,
+                                69: 1,
+                                70: 2,
+                                71: 0,
+                                72: 0,
+                                73: 0,
+                                74: 0,
+                                75: 0,
+                                76: 0,
+                                77: 1,
+                                78: 2,
+                                79: 0,
+                                80: 0,
+                                81: 0,
+                                82: 0,
+                                83: 0,
+                                84: 0,
+                                85: 1,
+                                86: 2,
+                                87: 0,
+                                88: 0,
+                                89: 0,
+                                90: 0,
+                                91: 1,
+                                92: 0,
+                                93: 1,
+                                94: 2,
+                                95: 0,
+                                96: 0,
+                                97: 0,
+                                98: 0,
+                                99: 1,
+                                100: 0,
+                                101: 1,
+                                102: 2,
+                                103: 0,
+                                104: 0,
+                                105: 0,
+                                106: 0,
+                                107: 1,
+                                108: 0,
+                                109: 1,
+                                110: 2,
+                                111: 0,
+                                112: 0,
+                                113: 0,
+                                114: 0,
+                                115: 1,
+                                116: 0,
+                                117: 1,
+                                118: 2,
+                                119: 0,
+                                120: 0,
+                                121: 0,
+                                122: 0,
+                                123: 1,
+                                124: 0,
+                                125: 1,
+                                126: 2,
+                                127: 0,
+                                128: 0,
+                                129: 0,
+                                130: 0,
+                                131: 1,
+                                132: 0,
+                                133: 0,
+                                134: 1,
+                                135: 2,
+                                136: 0,
+                                137: 0,
+                                138: 0,
+                                139: 0,
+                                140: 1,
+                                141: 0,
+                                142: 1,
+                                143: 0,
+                                144: 0,
+                                145: 0,
+                                146: 0,
+                                147: 0,
+                                148: 1,
+                                149: 2,
+                                150: 0,
+                                151: 0,
+                                152: 0,
+                                153: 0,
+                                154: 1,
+                                155: 0,
+                                156: 0,
+                                157: 1,
+                                158: 2,
+                                159: 0,
+                                160: 0,
+                                161: 0,
+                                162: 0,
+                                163: 1,
+                                164: 0,
+                                165: 1,
+                                166: 0,
+                                167: 0,
+                                168: 0,
+                                169: 0,
+                                170: 0,
+                                171: 1,
+                                172: 2,
+                                173: 0,
+                                174: 0,
+                                175: 0,
+                                176: 0,
+                                177: 1,
+                                178: 0,
+                                179: 0,
+                                180: 1,
+                                181: 2,
+                                182: 0,
+                                183: 0,
+                                184: 0,
+                                185: 0,
+                                186: 1,
+                                187: 0,
+                                188: 1,
+                                189: 0,
+                                190: 0,
+                                191: 0,
+                                192: 0,
+                                193: 0,
+                                194: 1,
+                                195: 2,
+                                196: 0,
+                                197: 0,
+                                198: 0,
+                                199: 0,
+                                200: 1,
+                                201: 0,
+                                202: 0,
+                                203: 1,
+                                204: 2,
+                                205: 0,
+                                206: 0,
+                                207: 0,
+                                208: 0,
+                                209: 1,
+                                210: 0,
+                                211: 1,
+                                212: 0,
+                                213: 0,
+                                214: 0,
+                                215: 0,
+                                216: 0,
+                                217: 1,
+                                218: 2,
+                                219: 0,
+                                220: 0,
+                                221: 0,
+                                222: 0,
+                                223: 1,
+                                224: 0,
+                                225: 1,
+                                226: 0,
+                                227: 0,
+                                228: 0,
+                                229: 0,
+                                230: 0,
+                                231: 1,
+                                232: 2,
+                                233: 0,
+                                234: 0,
+                                235: 0,
+                                236: 0,
+                                237: 1,
+                                238: 0,
+                                239: 0,
+                                240: 1,
+                                241: 2,
+                                242: 0,
+                                243: 0,
+                                244: 0,
+                                245: 0,
+                                246: 1,
+                                247: 0,
+                                248: 0,
+                                249: 0,
+                                250: 1,
+                                251: 2,
+                                252: 0,
+                                253: 0,
+                                254: 0,
+                                255: 0,
+                                256: 1,
+                                257: 0,
+                                258: 0,
+                                259: 0,
+                                260: 0,
+                                261: 0,
+                                262: 0,
+                                263: 0,
+                                264: 0,
+                                265: 0,
+                                266: 0,
+                                267: 0,
+                                268: 0,
+                                269: 0,
+                                270: 0,
+                                271: 0,
+                                272: 0,
+                                273: 0,
+                                274: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_loop_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_loop_debug.llvm-ir.snap
@@ -1,0 +1,3521 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 1,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 30,
+                edge_count: 49,
+                edges: (3, 2), (4, 2), (5, 2), (6, 2), (7, 2), (2, 8), (1, 9), (3, 9), (10, 9), (11, 9), (12, 9), (9, 7), (14, 13), (15, 13), (16, 13), (17, 13), (13, 6), (13, 12), (13, 10), (19, 18), (1, 18), (3, 18), (11, 18), (20, 18), (21, 18), (18, 17), (18, 21), (18, 15), (23, 22), (24, 22), (22, 20), (22, 19), (1, 25), (26, 25), (25, 16), (25, 24), (25, 14), (25, 23), (1, 27), (3, 27), (0, 27), (28, 27), (27, 5), (27, 26), (27, 11), (1, 29), (29, 28), (29, 4), (29, 3),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    1,
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 8,
+                            edge_count: 6,
+                            edges: (1, 2), (4, 3), (5, 3), (0, 3), (6, 5), (7, 4),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: None,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.end.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 40,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                3,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [
+                                                    NoUnwind,
+                                                ],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 40,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.end.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 2,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    3,
+                                ),
+                            },
+                        ),
+                    ),
+                    4: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    5: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    6: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    7: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    8: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    9: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 24,
+                            edge_count: 24,
+                            edges: (4, 5), (7, 6), (8, 6), (10, 9), (0, 9), (9, 8), (7, 11), (11, 10), (1, 12), (13, 12), (14, 12), (12, 7), (15, 13), (2, 16), (17, 16), (16, 14), (18, 17), (20, 19), (3, 19), (1, 21), (22, 21), (2, 21), (21, 20), (23, 22),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    41,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        38,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        40,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                38,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                40,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        39,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    40,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                39,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        38,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    39,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            37,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    38,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    Nil,
+                                ),
+                                14: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                37,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                15: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        33,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551615,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    37,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551615,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        36,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                36,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                21: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            33,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    36,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Edge(
+                                    Nil,
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 1,
+                                10: 2,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 1,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 1,
+                                19: 0,
+                                20: 1,
+                                21: 2,
+                                22: 0,
+                                23: 0,
+                            },
+                        },
+                    ),
+                    10: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    33,
+                                ),
+                            },
+                        ),
+                    ),
+                    11: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    7,
+                                ),
+                            },
+                        ),
+                    ),
+                    12: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    35,
+                                ),
+                            ),
+                        ),
+                    ),
+                    13: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 15,
+                            edge_count: 13,
+                            edges: (3, 2), (2, 4), (2, 5), (7, 6), (0, 6), (8, 6), (6, 3), (9, 8), (10, 7), (12, 11), (1, 11), (11, 13), (14, 12),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        34,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    41,
+                                                ),
+                                                false_dest: Number(
+                                                    35,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                34,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                35,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    34,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                29,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        },
+                                                        Number(
+                                                            16,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    33,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                            },
+                        },
+                    ),
+                    14: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    12,
+                                ),
+                            },
+                        ),
+                    ),
+                    15: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    29,
+                                ),
+                            },
+                        ),
+                    ),
+                    16: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    32,
+                                ),
+                            ),
+                        ),
+                    ),
+                    17: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    32,
+                                ),
+                            ),
+                        ),
+                    ),
+                    18: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 63,
+                            edge_count: 70,
+                            edges: (5, 4), (4, 6), (4, 7), (9, 8), (10, 8), (0, 8), (8, 5), (11, 9), (13, 12), (14, 12), (12, 10), (16, 15), (10, 15), (15, 13), (17, 14), (19, 18), (20, 18), (22, 21), (1, 21), (21, 20), (19, 23), (23, 22), (2, 24), (25, 24), (26, 24), (24, 19), (28, 27), (3, 27), (2, 29), (30, 29), (31, 29), (29, 28), (26, 32), (33, 32), (32, 31), (35, 34), (36, 34), (38, 37), (1, 37), (37, 36), (35, 39), (39, 38), (2, 40), (41, 40), (42, 40), (40, 35), (26, 43), (44, 43), (43, 42), (46, 45), (3, 45), (2, 47), (48, 47), (26, 47), (47, 46), (26, 49), (50, 49), (49, 51), (53, 52), (51, 52), (52, 26), (54, 50), (55, 25), (56, 30), (57, 33), (58, 41), (59, 44), (60, 48), (61, 16), (62, 53),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        31,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    32,
+                                                ),
+                                                false_dest: Number(
+                                                    16,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                31,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                32,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                16,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                8: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        30,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    31,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                30,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                11: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        18,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    30,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                18,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            14,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                30,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        },
+                                                        Number(
+                                                            16,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    18,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        28,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                26,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                20: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                28,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                21: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        27,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    28,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                27,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                23: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    27,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            17,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    26,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                17,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                27: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        25,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                25,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                29: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            24,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    25,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                30: Edge(
+                                    Nil,
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                24,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    24,
+                                                ),
+                                                nuw: true,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                33: Edge(
+                                    Nil,
+                                ),
+                                34: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        23,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                35: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                21,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                36: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                23,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                37: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        22,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    23,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                38: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                22,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                39: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    22,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                40: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            20,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    21,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                20,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                43: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551615,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    20,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Edge(
+                                    Nil,
+                                ),
+                                45: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        19,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                46: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                19,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                47: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            17,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    19,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    29,
+                                                ),
+                                                nuw: true,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                50: Edge(
+                                    Nil,
+                                ),
+                                51: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                52: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            14,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                29,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        },
+                                                        Number(
+                                                            16,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    17,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                53: Edge(
+                                    Nil,
+                                ),
+                                54: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                56: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                57: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551615,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                62: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 1,
+                                10: 0,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 1,
+                                17: 0,
+                                18: 1,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 1,
+                                24: 2,
+                                25: 0,
+                                26: 0,
+                                27: 1,
+                                28: 0,
+                                29: 1,
+                                30: 2,
+                                31: 0,
+                                32: 0,
+                                33: 1,
+                                34: 0,
+                                35: 0,
+                                36: 1,
+                                37: 0,
+                                38: 1,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 1,
+                                44: 2,
+                                45: 0,
+                                46: 0,
+                                47: 1,
+                                48: 0,
+                                49: 0,
+                                50: 1,
+                                51: 0,
+                                52: 1,
+                                53: 2,
+                                54: 0,
+                                55: 0,
+                                56: 1,
+                                57: 0,
+                                58: 0,
+                                59: 1,
+                                60: 0,
+                                61: 0,
+                                62: 0,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 0,
+                                68: 0,
+                                69: 0,
+                            },
+                        },
+                    ),
+                    19: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    15,
+                                ),
+                            },
+                        ),
+                    ),
+                    20: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    16,
+                                ),
+                            ),
+                        ),
+                    ),
+                    21: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    16,
+                                ),
+                            ),
+                        ),
+                    ),
+                    22: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 5,
+                            edges: (1, 2), (0, 3), (4, 3), (3, 5), (6, 4),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    16,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                16,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        And(
+                                            And {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551614,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551614,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    23: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    11,
+                                ),
+                            },
+                        ),
+                    ),
+                    24: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    14,
+                                ),
+                            ),
+                        ),
+                    ),
+                    25: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 20,
+                            edge_count: 19,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (0, 5), (7, 5), (5, 2), (8, 7), (9, 6), (11, 10), (12, 10), (10, 13), (14, 12), (16, 15), (17, 15), (15, 11), (18, 17), (0, 19), (19, 16),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    32,
+                                                ),
+                                                false_dest: Number(
+                                                    14,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                32,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                14,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                10: Operation(
+                                    Instruction(
+                                        And(
+                                            And {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551615,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551615,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Instruction(
+                                        ZExt(
+                                            ZExt {
+                                                operand: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 1,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                            },
+                        },
+                    ),
+                    26: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    9,
+                                ),
+                            ),
+                        ),
+                    ),
+                    27: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 17,
+                            edge_count: 15,
+                            edges: (4, 3), (3, 5), (3, 6), (8, 7), (0, 7), (9, 7), (7, 4), (10, 9), (11, 8), (1, 12), (13, 12), (2, 14), (15, 14), (14, 13), (16, 15),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    41,
+                                                ),
+                                                false_dest: Number(
+                                                    9,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                9,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 16,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 3,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                            },
+                        },
+                    ),
+                    28: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    6,
+                                ),
+                            ),
+                        ),
+                    ),
+                    29: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 32,
+                            edge_count: 30,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (7, 5), (8, 5), (5, 2), (9, 8), (10, 6), (0, 11), (12, 11), (11, 7), (13, 12), (15, 14), (16, 14), (17, 14), (18, 14), (19, 14), (20, 19), (21, 18), (22, 17), (23, 15), (25, 24), (26, 24), (16, 24), (27, 26), (28, 25), (30, 29), (29, 16), (31, 30),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    6,
+                                                ),
+                                                false_dest: Number(
+                                                    41,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                6,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: ULT,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 10,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 10,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    IntPredicate(
+                                        ULT,
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 4294967295,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967295,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.memset.p0.i64",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 8,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 1,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 8,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 1,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                3,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                            Alignment(
+                                                                16,
+                                                            ),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 8,
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 40,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 1,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Edge(
+                                    Nil,
+                                ),
+                                19: Edge(
+                                    Nil,
+                                ),
+                                20: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 1,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 40,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 8,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.memset.p0.i64",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 8,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 1,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.start.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 40,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                3,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [
+                                                    NoUnwind,
+                                                ],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Edge(
+                                    Nil,
+                                ),
+                                27: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 40,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.start.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 16,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                30: Edge(
+                                    Nil,
+                                ),
+                                31: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 1,
+                                15: 2,
+                                16: 3,
+                                17: 4,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 1,
+                                24: 2,
+                                25: 0,
+                                26: 0,
+                                27: 0,
+                                28: 0,
+                                29: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 3,
+                    4: 4,
+                    5: 0,
+                    6: 0,
+                    7: 1,
+                    8: 2,
+                    9: 3,
+                    10: 4,
+                    11: 0,
+                    12: 0,
+                    13: 1,
+                    14: 2,
+                    15: 3,
+                    16: 0,
+                    17: 1,
+                    18: 2,
+                    19: 0,
+                    20: 1,
+                    21: 2,
+                    22: 3,
+                    23: 4,
+                    24: 5,
+                    25: 0,
+                    26: 1,
+                    27: 2,
+                    28: 0,
+                    29: 1,
+                    30: 0,
+                    31: 1,
+                    32: 0,
+                    33: 1,
+                    34: 0,
+                    35: 1,
+                    36: 2,
+                    37: 3,
+                    38: 0,
+                    39: 1,
+                    40: 2,
+                    41: 3,
+                    42: 0,
+                    43: 1,
+                    44: 2,
+                    45: 0,
+                    46: 0,
+                    47: 1,
+                    48: 2,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_mutual_diverge_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_mutual_diverge_debug.llvm-ir.snap
@@ -1,0 +1,306 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 2,
+    edge_count: 0,
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 5,
+                            edges: (1, 0), (0, 2), (4, 3), (3, 1), (5, 4),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "diverge1",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "diverge1",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+        1: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 5,
+                            edges: (1, 0), (0, 2), (4, 3), (3, 1), (5, 4),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "diverge2",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "diverge2",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {},
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_switch_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_switch_debug.llvm-ir.snap
@@ -1,0 +1,1620 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 4,
+    edge_count: 2,
+    edges: (1, 0), (2, 1),
+    node weights: {
+        0: Operation(
+            GlobalVariable(
+                GlobalVariable {
+                    name: Name(
+                        "str",
+                    ),
+                    linkage: Private,
+                    visibility: Default,
+                    is_constant: true,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    addr_space: 0,
+                    dll_storage_class: Default,
+                    thread_local_mode: NotThreadLocal,
+                    unnamed_addr: Some(
+                        Global,
+                    ),
+                    initializer: Some(
+                        ConstantRef(
+                            Array {
+                                element_type: TypeRef(
+                                    IntegerType {
+                                        bits: 8,
+                                    },
+                                ),
+                                elements: [
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 114,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 101,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 97,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 99,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 104,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 101,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 100,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 32,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 100,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 101,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 102,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 97,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 117,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 108,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 116,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 0,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ),
+                    section: None,
+                    comdat: None,
+                    alignment: 1,
+                    debugloc: None,
+                },
+            ),
+        ),
+        1: Edge(
+            Nil,
+        ),
+        2: Operation(
+            Constant(
+                ConstantRef(
+                    Array {
+                        element_type: TypeRef(
+                            IntegerType {
+                                bits: 8,
+                            },
+                        ),
+                        elements: [
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 114,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 101,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 97,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 99,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 104,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 101,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 100,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 32,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 100,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 101,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 102,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 97,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 117,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 108,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 116,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 0,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 32,
+                edge_count: 41,
+                edges: (0, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1), (1, 12), (14, 13), (13, 11), (16, 15), (15, 10), (18, 17), (17, 9), (20, 19), (19, 8), (22, 21), (21, 7), (24, 23), (23, 6), (26, 25), (25, 5), (28, 27), (27, 4), (30, 29), (29, 3), (0, 31), (31, 2), (31, 30), (31, 28), (31, 26), (31, 24), (31, 22), (31, 20), (31, 18), (31, 16), (31, 14),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 27,
+                            edge_count: 26,
+                            edges: (2, 1), (1, 3), (5, 4), (0, 4), (4, 2), (7, 6), (8, 6), (9, 6), (10, 6), (11, 6), (12, 6), (13, 6), (14, 6), (15, 6), (16, 6), (6, 5), (17, 16), (18, 15), (19, 14), (20, 13), (21, 12), (22, 11), (23, 10), (24, 9), (25, 8), (26, 7),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            14,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967295,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            10,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967293,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            8,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 77,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            7,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967263,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            6,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            5,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967291,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            4,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967289,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            3,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 5,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            2,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 3,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            1,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Edge(
+                                    Nil,
+                                ),
+                                11: Edge(
+                                    Nil,
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    Nil,
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967289,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967291,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967263,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 77,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967293,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                26: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967295,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                                6: 1,
+                                7: 2,
+                                8: 3,
+                                9: 4,
+                                10: 5,
+                                11: 6,
+                                12: 7,
+                                13: 8,
+                                14: 9,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 0,
+                                24: 0,
+                                25: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    3: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    4: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    5: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    6: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    7: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    8: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    9: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    10: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    11: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    12: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    13: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 8,
+                            edge_count: 6,
+                            edges: (0, 1), (3, 2), (4, 2), (2, 5), (6, 4), (7, 3),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                2: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "puts",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                GlobalReference {
+                                                                    name: Name(
+                                                                        "str",
+                                                                    ),
+                                                                    ty: TypeRef(
+                                                                        ArrayType {
+                                                                            element_type: TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 8,
+                                                                                },
+                                                                            ),
+                                                                            num_elements: 16,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [
+                                                            NonNull,
+                                                            Dereferenceable(
+                                                                1,
+                                                            ),
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Number(
+                                                        11,
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: true,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    Nil,
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "str",
+                                                ),
+                                                ty: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 8,
+                                                            },
+                                                        ),
+                                                        num_elements: 16,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "puts",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    14: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    10,
+                                ),
+                            ),
+                        ),
+                    ),
+                    15: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    16: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    9,
+                                ),
+                            ),
+                        ),
+                    ),
+                    17: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    18: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    8,
+                                ),
+                            ),
+                        ),
+                    ),
+                    19: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    20: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    7,
+                                ),
+                            ),
+                        ),
+                    ),
+                    21: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    22: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    6,
+                                ),
+                            ),
+                        ),
+                    ),
+                    23: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    24: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    5,
+                                ),
+                            ),
+                        ),
+                    ),
+                    25: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    26: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    4,
+                                ),
+                            ),
+                        ),
+                    ),
+                    27: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    28: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    3,
+                                ),
+                            ),
+                        ),
+                    ),
+                    29: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    30: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    2,
+                                ),
+                            ),
+                        ),
+                    ),
+                    31: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 12,
+                            edge_count: 11,
+                            edges: (0, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8), (1, 9), (1, 10), (1, 11),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Switch(
+                                            Switch {
+                                                operand: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dests: [
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            12,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            2,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 13,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            3,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 26,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            4,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 33,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            5,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 142,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            6,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1678,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            7,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 88,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            8,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 101,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                ],
+                                                default_dest: Number(
+                                                    10,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                2,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                3,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                4,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                5,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                6,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                8: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                7,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                9: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                8,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                10: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                9,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                10,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 2,
+                                4: 3,
+                                5: 4,
+                                6: 5,
+                                7: 6,
+                                8: 7,
+                                9: 8,
+                                10: 9,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 3,
+                    4: 4,
+                    5: 5,
+                    6: 6,
+                    7: 7,
+                    8: 8,
+                    9: 9,
+                    10: 10,
+                    11: 0,
+                    12: 0,
+                    13: 0,
+                    14: 0,
+                    15: 0,
+                    16: 0,
+                    17: 0,
+                    18: 0,
+                    19: 0,
+                    20: 0,
+                    21: 0,
+                    22: 0,
+                    23: 0,
+                    24: 0,
+                    25: 0,
+                    26: 0,
+                    27: 0,
+                    28: 0,
+                    29: 0,
+                    30: 0,
+                    31: 0,
+                    32: 1,
+                    33: 2,
+                    34: 3,
+                    35: 4,
+                    36: 5,
+                    37: 6,
+                    38: 7,
+                    39: 8,
+                    40: 9,
+                },
+            },
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_variables_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_variables_debug.llvm-ir.snap
@@ -1,0 +1,1476 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 4,
+    edge_count: 2,
+    edges: (1, 0), (2, 1),
+    node weights: {
+        0: Operation(
+            GlobalVariable(
+                GlobalVariable {
+                    name: Name(
+                        "global",
+                    ),
+                    linkage: External,
+                    visibility: Default,
+                    is_constant: false,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    addr_space: 0,
+                    dll_storage_class: Default,
+                    thread_local_mode: NotThreadLocal,
+                    unnamed_addr: None,
+                    initializer: Some(
+                        ConstantRef(
+                            Int {
+                                bits: 32,
+                                value: 5,
+                            },
+                        ),
+                    ),
+                    section: None,
+                    comdat: None,
+                    alignment: 4,
+                    debugloc: None,
+                },
+            ),
+        ),
+        1: Edge(
+            Nil,
+        ),
+        2: Operation(
+            Constant(
+                ConstantRef(
+                    Int {
+                        bits: 32,
+                        value: 5,
+                    },
+                ),
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 4,
+                edge_count: 3,
+                edges: (1, 2), (0, 2), (2, 3),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    1,
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 71,
+                            edge_count: 69,
+                            edges: (2, 3), (5, 4), (6, 4), (7, 4), (8, 6), (9, 5), (0, 10), (11, 10), (13, 12), (14, 12), (12, 11), (15, 14), (0, 16), (16, 13), (18, 17), (19, 17), (21, 20), (22, 20), (20, 19), (23, 22), (18, 24), (24, 21), (26, 25), (27, 25), (28, 26), (30, 29), (31, 29), (29, 27), (32, 31), (34, 33), (33, 30), (35, 34), (37, 36), (38, 36), (40, 39), (41, 39), (39, 38), (42, 41), (37, 43), (43, 40), (7, 44), (45, 44), (47, 46), (48, 46), (46, 45), (49, 48), (7, 50), (50, 47), (52, 51), (53, 51), (51, 37), (54, 53), (55, 52), (7, 56), (57, 56), (58, 57), (60, 59), (61, 59), (7, 59), (62, 61), (63, 60), (18, 64), (1, 64), (66, 65), (65, 7), (67, 66), (69, 68), (68, 18), (70, 69),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: None,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.end.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 4,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                4,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.end.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        14,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                19: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                20: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                22: Edge(
+                                    Nil,
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "global",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                26: Edge(
+                                    Nil,
+                                ),
+                                27: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                28: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "global",
+                                                ),
+                                                ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                30: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                31: Edge(
+                                    Nil,
+                                ),
+                                32: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                33: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "global",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                34: Edge(
+                                    Nil,
+                                ),
+                                35: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "global",
+                                                ),
+                                                ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                36: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                37: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                38: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                39: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                40: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                43: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                45: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                46: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                47: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                6,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                50: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    6,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                51: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "malloc",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            PointerType {
+                                                                                addr_space: 0,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            PointerType {
+                                                                addr_space: 0,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 4,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [
+                                                            NoUndef,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [
+                                                    DereferenceableOrNull(
+                                                        4,
+                                                    ),
+                                                ],
+                                                dest: Some(
+                                                    Number(
+                                                        5,
+                                                    ),
+                                                ),
+                                                function_attributes: [
+                                                    AllocSize {
+                                                        elt_size: 0,
+                                                        num_elts: None,
+                                                    },
+                                                ],
+                                                is_tail_call: true,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                52: Edge(
+                                    Nil,
+                                ),
+                                53: Edge(
+                                    Nil,
+                                ),
+                                54: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "malloc",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            PointerType {
+                                                                addr_space: 0,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                56: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 72,
+                                                        },
+                                                    ),
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                57: Edge(
+                                    Nil,
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 72,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.start.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 4,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                4,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Edge(
+                                    Nil,
+                                ),
+                                61: Edge(
+                                    Nil,
+                                ),
+                                62: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                63: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.start.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                64: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                65: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                66: Edge(
+                                    Nil,
+                                ),
+                                67: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                68: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                69: Edge(
+                                    Nil,
+                                ),
+                                70: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 2,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                                7: 1,
+                                8: 0,
+                                9: 1,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 0,
+                                15: 1,
+                                16: 0,
+                                17: 1,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 1,
+                                24: 0,
+                                25: 0,
+                                26: 1,
+                                27: 0,
+                                28: 0,
+                                29: 0,
+                                30: 0,
+                                31: 0,
+                                32: 0,
+                                33: 1,
+                                34: 0,
+                                35: 1,
+                                36: 0,
+                                37: 0,
+                                38: 0,
+                                39: 0,
+                                40: 0,
+                                41: 1,
+                                42: 0,
+                                43: 1,
+                                44: 0,
+                                45: 0,
+                                46: 0,
+                                47: 0,
+                                48: 0,
+                                49: 1,
+                                50: 0,
+                                51: 0,
+                                52: 0,
+                                53: 0,
+                                54: 1,
+                                55: 0,
+                                56: 0,
+                                57: 1,
+                                58: 2,
+                                59: 0,
+                                60: 0,
+                                61: 0,
+                                62: 1,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 0,
+                                68: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_add_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_add_debug.llvm-ir.snap
@@ -1,0 +1,765 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 4,
+    edge_count: 3,
+    edges: (1, 0), (0, 1), (2, 3),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 10,
+                edge_count: 11,
+                edges: (2, 3), (4, 3), (3, 5), (0, 6), (2, 6), (1, 6), (7, 6), (6, 8), (1, 9), (9, 4), (9, 7),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "add2",
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "a",
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "b",
+                                ),
+                            },
+                        ),
+                    ),
+                    3: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 3,
+                            edge_count: 2,
+                            edges: (0, 1), (1, 2),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "b",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "b",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                            },
+                        },
+                    ),
+                    4: Edge(
+                        CF(
+                            Some(
+                                Name(
+                                    "done",
+                                ),
+                            ),
+                        ),
+                    ),
+                    5: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    6: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 17,
+                            edge_count: 16,
+                            edges: (4, 3), (3, 5), (7, 6), (8, 6), (9, 6), (6, 4), (0, 10), (10, 7), (1, 11), (12, 11), (11, 9), (13, 12), (2, 14), (15, 14), (14, 8), (16, 15),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "add2",
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "b",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "a",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp4",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp4",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "add2",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        LocalOperand {
+                                                            name: Name(
+                                                                "tmp2",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Name(
+                                                                "tmp3",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp4",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp2",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp3",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "add2",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "b",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "tmp3",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Sub(
+                                            Sub {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "a",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "tmp2",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 2,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 1,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 0,
+                                15: 0,
+                            },
+                        },
+                    ),
+                    7: Edge(
+                        CF(
+                            Some(
+                                Name(
+                                    "recurse",
+                                ),
+                            ),
+                        ),
+                    ),
+                    8: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    9: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 10,
+                            edge_count: 9,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (0, 5), (7, 5), (5, 2), (8, 7), (9, 6),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "a",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Name(
+                                                        "tmp1",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Name(
+                                                    "done",
+                                                ),
+                                                false_dest: Name(
+                                                    "recurse",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Name(
+                                                "done",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Name(
+                                                "recurse",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "a",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "tmp1",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                    3: 0,
+                    4: 1,
+                    5: 2,
+                    6: 3,
+                    7: 0,
+                    8: 0,
+                    9: 0,
+                    10: 1,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "add2",
+                },
+            ),
+        ),
+        2: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 4,
+                edge_count: 3,
+                edges: (0, 2), (1, 2), (2, 3),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "a",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "b",
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 5,
+                            edges: (3, 2), (2, 4), (0, 5), (1, 5), (5, 3),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "a",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "b",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "a",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Name(
+                                                        "b",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Name(
+                                                    "tmp1",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                },
+            },
+        ),
+        3: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "add1",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+        2: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_alias_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_alias_debug.llvm-ir.snap
@@ -1,0 +1,324 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 7,
+    edge_count: 6,
+    edges: (2, 1), (1, 3), (5, 4), (4, 2), (0, 6), (6, 5),
+    node weights: {
+        0: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "some_function",
+                },
+            ),
+        ),
+        1: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "alias_func",
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 9,
+                            edge_count: 8,
+                            edges: (2, 1), (1, 3), (5, 4), (6, 4), (4, 2), (7, 6), (0, 8), (8, 5),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "alias_func",
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "alias_func",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 42,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "result",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 42,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "alias_func",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        2: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "alias_func",
+                },
+            ),
+        ),
+        3: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "main",
+                },
+            ),
+        ),
+        4: Operation(
+            GlobalAlias(
+                GlobalAlias {
+                    name: Name(
+                        "alias_func",
+                    ),
+                    aliasee: ConstantRef(
+                        GlobalReference {
+                            name: Name(
+                                "some_function",
+                            ),
+                            ty: TypeRef(
+                                FuncType {
+                                    result_type: TypeRef(
+                                        IntegerType {
+                                            bits: 32,
+                                        },
+                                    ),
+                                    param_types: [
+                                        TypeRef(
+                                            IntegerType {
+                                                bits: 32,
+                                            },
+                                        ),
+                                    ],
+                                    is_var_arg: false,
+                                },
+                            ),
+                        },
+                    ),
+                    linkage: External,
+                    visibility: Default,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    addr_space: 0,
+                    dll_storage_class: Default,
+                    thread_local_mode: NotThreadLocal,
+                    unnamed_addr: None,
+                },
+            ),
+        ),
+        5: Edge(
+            Nil,
+        ),
+        6: Operation(
+            Constant(
+                ConstantRef(
+                    GlobalReference {
+                        name: Name(
+                            "some_function",
+                        ),
+                        ty: TypeRef(
+                            FuncType {
+                                result_type: TypeRef(
+                                    IntegerType {
+                                        bits: 32,
+                                    },
+                                ),
+                                param_types: [
+                                    TypeRef(
+                                        IntegerType {
+                                            bits: 32,
+                                        },
+                                    ),
+                                ],
+                                is_var_arg: false,
+                            },
+                        ),
+                    },
+                ),
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_diverge_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_diverge_debug.llvm-ir.snap
@@ -1,0 +1,186 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 2,
+    edge_count: 2,
+    edges: (1, 0), (0, 1),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "diverge",
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (0, 6), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "diverge",
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "diverge",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "diverge",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "diverge",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_fact_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_fact_debug.llvm-ir.snap
@@ -1,0 +1,1021 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 2,
+    edge_count: 2,
+    edges: (1, 0), (0, 1),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 13,
+                edge_count: 17,
+                edges: (3, 2), (4, 2), (5, 2), (2, 6), (3, 7), (0, 7), (8, 7), (9, 7), (7, 5), (3, 10), (11, 10), (10, 4), (1, 12), (12, 11), (12, 9), (12, 8), (12, 3),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "fact",
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 5,
+                            edge_count: 4,
+                            edges: (2, 1), (1, 3), (0, 4), (4, 2),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            14,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    2,
+                                ),
+                            },
+                        ),
+                    ),
+                    4: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    13,
+                                ),
+                            ),
+                        ),
+                    ),
+                    5: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    13,
+                                ),
+                            ),
+                        ),
+                    ),
+                    6: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    7: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 20,
+                            edge_count: 19,
+                            edges: (3, 4), (0, 5), (6, 5), (8, 7), (9, 7), (7, 6), (11, 10), (12, 10), (10, 9), (1, 13), (13, 11), (15, 14), (16, 14), (14, 12), (17, 16), (2, 18), (18, 15), (2, 19), (19, 8),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "fact",
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                13,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                7: Operation(
+                                    Instruction(
+                                        Mul(
+                                            Mul {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                10: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "fact",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                10,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NoUndef,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Number(
+                                                        11,
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    Nil,
+                                ),
+                                12: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                13: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "fact",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Sub(
+                                            Sub {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 0,
+                                6: 0,
+                                7: 1,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                            },
+                        },
+                    ),
+                    8: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    3,
+                                ),
+                            },
+                        ),
+                    ),
+                    9: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    7,
+                                ),
+                            ),
+                        ),
+                    ),
+                    10: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 6,
+                            edge_count: 4,
+                            edges: (1, 2), (0, 3), (4, 3), (5, 4),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                13,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                            },
+                        },
+                    ),
+                    11: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    6,
+                                ),
+                            ),
+                        ),
+                    ),
+                    12: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 21,
+                            edge_count: 19,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (7, 5), (8, 5), (5, 2), (9, 8), (10, 6), (12, 11), (11, 7), (12, 13), (0, 13), (15, 14), (14, 12), (16, 15), (18, 17), (17, 19), (20, 18),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    6,
+                                                ),
+                                                false_dest: Number(
+                                                    7,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                6,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                7,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                13: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Edge(
+                                    Nil,
+                                ),
+                                19: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                20: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 0,
+                    4: 0,
+                    5: 1,
+                    6: 2,
+                    7: 3,
+                    8: 0,
+                    9: 0,
+                    10: 1,
+                    11: 0,
+                    12: 0,
+                    13: 0,
+                    14: 1,
+                    15: 2,
+                    16: 3,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "fact",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_hello_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_hello_debug.llvm-ir.snap
@@ -1,0 +1,92 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 2,
+    edge_count: 1,
+    edges: (0, 1),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 2,
+                edge_count: 1,
+                edges: (0, 1),
+                node weights: {
+                    0: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 4,
+                            edge_count: 3,
+                            edges: (1, 0), (0, 2), (3, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    Nil,
+                                ),
+                                2: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                3: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                            },
+                        },
+                    ),
+                    1: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "main",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_ifunc_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_ifunc_debug.llvm-ir.snap
@@ -1,0 +1,917 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 12,
+    edge_count: 11,
+    edges: (1, 0), (0, 2), (4, 3), (3, 1), (6, 5), (5, 4), (8, 7), (9, 7), (7, 6), (10, 8), (11, 9),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "indirect_func",
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 9,
+                            edge_count: 8,
+                            edges: (2, 1), (1, 3), (5, 4), (6, 4), (4, 2), (7, 6), (0, 8), (8, 5),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "indirect_func",
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "indirect_func",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 32,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 5,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "result",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "indirect_func",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "indirect_func",
+                },
+            ),
+        ),
+        2: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "main",
+                },
+            ),
+        ),
+        3: Operation(
+            GlobalIFunc(
+                GlobalIFunc {
+                    name: Name(
+                        "indirect_func",
+                    ),
+                    linkage: External,
+                    visibility: Default,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    resolver_fn: ConstantRef(
+                        GlobalReference {
+                            name: Name(
+                                "resolver",
+                            ),
+                            ty: TypeRef(
+                                FuncType {
+                                    result_type: TypeRef(
+                                        PointerType {
+                                            addr_space: 0,
+                                        },
+                                    ),
+                                    param_types: [],
+                                    is_var_arg: false,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ),
+        4: Edge(
+            Nil,
+        ),
+        5: Operation(
+            Constant(
+                ConstantRef(
+                    GlobalReference {
+                        name: Name(
+                            "resolver",
+                        ),
+                        ty: TypeRef(
+                            FuncType {
+                                result_type: TypeRef(
+                                    PointerType {
+                                        addr_space: 0,
+                                    },
+                                ),
+                                param_types: [],
+                                is_var_arg: false,
+                            },
+                        ),
+                    },
+                ),
+            ),
+        ),
+        6: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "resolver",
+                },
+            ),
+        ),
+        7: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 4,
+                edge_count: 3,
+                edges: (0, 2), (1, 2), (2, 3),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "impl_slow",
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "impl_fast",
+                            },
+                        ),
+                    ),
+                    2: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 18,
+                            edge_count: 17,
+                            edges: (3, 2), (2, 4), (6, 5), (7, 5), (8, 5), (5, 3), (0, 9), (9, 8), (1, 10), (10, 7), (12, 11), (13, 11), (14, 11), (11, 6), (15, 14), (16, 13), (17, 12),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "impl_slow",
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "impl_fast",
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "func",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            PointerType {
+                                                                addr_space: 0,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "func",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        Select(
+                                            Select {
+                                                condition: LocalOperand {
+                                                    name: Name(
+                                                        "cond",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_value: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "impl_fast",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                FuncType {
+                                                                    result_type: TypeRef(
+                                                                        IntegerType {
+                                                                            bits: 32,
+                                                                        },
+                                                                    ),
+                                                                    param_types: [
+                                                                        TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    is_var_arg: false,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                false_value: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "impl_slow",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                FuncType {
+                                                                    result_type: TypeRef(
+                                                                        IntegerType {
+                                                                            bits: 32,
+                                                                        },
+                                                                    ),
+                                                                    param_types: [
+                                                                        TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    is_var_arg: false,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "func",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "cond",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "impl_slow",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "impl_fast",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "cond",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    Nil,
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 2,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 1,
+                                12: 2,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                            },
+                        },
+                    ),
+                    3: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 0,
+                },
+            },
+        ),
+        8: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "impl_slow",
+                },
+            ),
+        ),
+        9: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "impl_fast",
+                },
+            ),
+        ),
+        10: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "x",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (0, 4), (5, 4), (4, 2), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "x",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Mul(
+                                            Mul {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "x",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "result",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        11: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "x",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (0, 4), (5, 4), (4, 2), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "x",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "result",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "result",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Shl(
+                                            Shl {
+                                                operand0: LocalOperand {
+                                                    name: Name(
+                                                        "x",
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Name(
+                                                    "result",
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 0,
+        6: 0,
+        7: 1,
+        8: 0,
+        9: 0,
+        10: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_jump_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_jump_debug.llvm-ir.snap
@@ -1,0 +1,122 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 2,
+    edge_count: 1,
+    edges: (0, 1),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 5,
+                edge_count: 3,
+                edges: (2, 1), (1, 3), (4, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Name(
+                                    "a",
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: None,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            Some(
+                                Name(
+                                    "done",
+                                ),
+                            ),
+                        ),
+                    ),
+                    3: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    4: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Name(
+                                                    "done",
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Name(
+                                                "done",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                    2: 0,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "jump",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_linkedlist_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_linkedlist_debug.llvm-ir.snap
@@ -1,0 +1,7457 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 6,
+    edge_count: 3,
+    edges: (0, 1), (2, 3), (4, 5),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 18,
+                            edge_count: 17,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (7, 6), (8, 6), (9, 6), (6, 5), (10, 9), (11, 7), (13, 12), (12, 8), (13, 14), (0, 14), (16, 15), (15, 13), (17, 16),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            5,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        ZExt(
+                                            ZExt {
+                                                operand: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: NE,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    IntPredicate(
+                                        NE,
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 1,
+                                6: 2,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 0,
+                                15: 0,
+                                16: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "takes_opaque_struct",
+                },
+            ),
+        ),
+        2: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 167,
+                            edge_count: 169,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (7, 6), (8, 6), (9, 6), (6, 5), (10, 9), (11, 8), (13, 12), (12, 7), (15, 14), (16, 14), (17, 14), (14, 13), (18, 17), (19, 16), (21, 20), (20, 15), (23, 22), (24, 22), (25, 22), (22, 21), (26, 25), (27, 24), (29, 28), (28, 23), (31, 30), (32, 30), (33, 30), (30, 29), (34, 33), (35, 32), (37, 36), (36, 31), (39, 38), (40, 38), (41, 38), (38, 37), (42, 41), (43, 40), (45, 44), (44, 39), (47, 46), (48, 46), (49, 46), (46, 45), (50, 49), (51, 48), (53, 52), (52, 47), (55, 54), (56, 54), (57, 54), (54, 53), (58, 57), (59, 56), (61, 60), (60, 55), (63, 62), (64, 62), (65, 62), (62, 61), (66, 65), (67, 64), (69, 68), (70, 68), (72, 71), (73, 71), (74, 71), (71, 69), (75, 74), (76, 73), (78, 77), (72, 77), (70, 79), (80, 79), (81, 79), (79, 78), (82, 81), (83, 80), (85, 84), (70, 84), (63, 86), (87, 86), (88, 86), (86, 85), (89, 88), (90, 87), (92, 91), (93, 91), (94, 93), (72, 95), (96, 95), (97, 95), (95, 92), (98, 97), (99, 96), (101, 100), (102, 100), (104, 103), (105, 103), (103, 102), (106, 105), (108, 107), (107, 104), (72, 109), (110, 109), (111, 109), (109, 101), (112, 111), (113, 110), (115, 114), (116, 114), (117, 116), (70, 118), (119, 118), (120, 118), (118, 115), (121, 120), (122, 119), (124, 123), (125, 123), (127, 126), (128, 126), (126, 125), (129, 128), (108, 130), (130, 127), (70, 131), (132, 131), (133, 131), (131, 124), (134, 133), (135, 132), (137, 136), (138, 136), (139, 138), (63, 140), (141, 140), (142, 140), (140, 137), (143, 142), (144, 141), (146, 145), (147, 145), (108, 148), (148, 147), (63, 149), (150, 149), (151, 149), (149, 146), (152, 151), (153, 150), (108, 154), (0, 154), (156, 155), (155, 72), (157, 156), (159, 158), (158, 70), (160, 159), (162, 161), (161, 63), (163, 162), (165, 164), (164, 108), (166, 165),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            35,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                35,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        34,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    35,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                34,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        33,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    34,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        32,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    33,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                32,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        31,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    32,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                31,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        30,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    31,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                30,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                22: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        29,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    30,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                24: Edge(
+                                    Nil,
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                27: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        28,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    29,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                28,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                30: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        27,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    28,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                27,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Edge(
+                                    Nil,
+                                ),
+                                33: Edge(
+                                    Nil,
+                                ),
+                                34: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                35: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                36: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    27,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                37: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                26,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                38: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        25,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    26,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                39: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                25,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                40: Edge(
+                                    Nil,
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                43: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        24,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    25,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                45: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                24,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                46: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        23,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    24,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                47: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                23,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Edge(
+                                    Nil,
+                                ),
+                                50: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                51: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                52: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        22,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    23,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                53: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                22,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                54: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    22,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                21,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                56: Edge(
+                                    Nil,
+                                ),
+                                57: Edge(
+                                    Nil,
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        20,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    21,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                20,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                62: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    20,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                63: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                64: Edge(
+                                    Nil,
+                                ),
+                                65: Edge(
+                                    Nil,
+                                ),
+                                66: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                67: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                68: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        19,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                69: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                19,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                70: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                71: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    19,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                72: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                73: Edge(
+                                    Nil,
+                                ),
+                                74: Edge(
+                                    Nil,
+                                ),
+                                75: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                76: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                77: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        18,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                78: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                18,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                79: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    18,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                80: Edge(
+                                    Nil,
+                                ),
+                                81: Edge(
+                                    Nil,
+                                ),
+                                82: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                83: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                84: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                85: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                17,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                86: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    17,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                87: Edge(
+                                    Nil,
+                                ),
+                                88: Edge(
+                                    Nil,
+                                ),
+                                89: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                90: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                91: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        16,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                92: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                16,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                93: Edge(
+                                    Nil,
+                                ),
+                                94: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                95: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    16,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                96: Edge(
+                                    Nil,
+                                ),
+                                97: Edge(
+                                    Nil,
+                                ),
+                                98: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                99: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                100: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                101: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                102: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                103: Operation(
+                                    Instruction(
+                                        SDiv(
+                                            SDiv {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        14,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 4,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                exact: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                104: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                105: Edge(
+                                    Nil,
+                                ),
+                                106: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                107: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                108: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                109: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                110: Edge(
+                                    Nil,
+                                ),
+                                111: Edge(
+                                    Nil,
+                                ),
+                                112: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                113: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                114: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                115: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                116: Edge(
+                                    Nil,
+                                ),
+                                117: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                118: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                119: Edge(
+                                    Nil,
+                                ),
+                                120: Edge(
+                                    Nil,
+                                ),
+                                121: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                122: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                123: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                124: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                125: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                126: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 3,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                127: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                128: Edge(
+                                    Nil,
+                                ),
+                                129: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                130: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                131: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                132: Edge(
+                                    Nil,
+                                ),
+                                133: Edge(
+                                    Nil,
+                                ),
+                                134: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                135: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                136: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                137: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                138: Edge(
+                                    Nil,
+                                ),
+                                139: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                140: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                141: Edge(
+                                    Nil,
+                                ),
+                                142: Edge(
+                                    Nil,
+                                ),
+                                143: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                144: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                145: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                146: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                6,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                147: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                148: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                149: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    6,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                150: Edge(
+                                    Nil,
+                                ),
+                                151: Edge(
+                                    Nil,
+                                ),
+                                152: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                153: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                154: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                155: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                156: Edge(
+                                    Nil,
+                                ),
+                                157: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                158: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeB",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                159: Edge(
+                                    Nil,
+                                ),
+                                160: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                161: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.NodeA",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                162: Edge(
+                                    Nil,
+                                ),
+                                163: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                164: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                165: Edge(
+                                    Nil,
+                                ),
+                                166: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 1,
+                                6: 2,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 2,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 1,
+                                22: 2,
+                                23: 0,
+                                24: 0,
+                                25: 0,
+                                26: 0,
+                                27: 0,
+                                28: 0,
+                                29: 1,
+                                30: 2,
+                                31: 0,
+                                32: 0,
+                                33: 0,
+                                34: 0,
+                                35: 0,
+                                36: 0,
+                                37: 1,
+                                38: 2,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 0,
+                                44: 0,
+                                45: 1,
+                                46: 2,
+                                47: 0,
+                                48: 0,
+                                49: 0,
+                                50: 0,
+                                51: 0,
+                                52: 0,
+                                53: 1,
+                                54: 2,
+                                55: 0,
+                                56: 0,
+                                57: 0,
+                                58: 0,
+                                59: 0,
+                                60: 0,
+                                61: 1,
+                                62: 2,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 1,
+                                68: 0,
+                                69: 1,
+                                70: 2,
+                                71: 0,
+                                72: 0,
+                                73: 0,
+                                74: 0,
+                                75: 1,
+                                76: 0,
+                                77: 1,
+                                78: 2,
+                                79: 0,
+                                80: 0,
+                                81: 0,
+                                82: 0,
+                                83: 1,
+                                84: 0,
+                                85: 1,
+                                86: 2,
+                                87: 0,
+                                88: 0,
+                                89: 0,
+                                90: 0,
+                                91: 1,
+                                92: 0,
+                                93: 0,
+                                94: 1,
+                                95: 2,
+                                96: 0,
+                                97: 0,
+                                98: 0,
+                                99: 0,
+                                100: 1,
+                                101: 0,
+                                102: 1,
+                                103: 0,
+                                104: 0,
+                                105: 0,
+                                106: 0,
+                                107: 0,
+                                108: 1,
+                                109: 2,
+                                110: 0,
+                                111: 0,
+                                112: 0,
+                                113: 0,
+                                114: 1,
+                                115: 0,
+                                116: 0,
+                                117: 1,
+                                118: 2,
+                                119: 0,
+                                120: 0,
+                                121: 0,
+                                122: 0,
+                                123: 1,
+                                124: 0,
+                                125: 1,
+                                126: 0,
+                                127: 0,
+                                128: 0,
+                                129: 0,
+                                130: 0,
+                                131: 1,
+                                132: 2,
+                                133: 0,
+                                134: 0,
+                                135: 0,
+                                136: 0,
+                                137: 1,
+                                138: 0,
+                                139: 0,
+                                140: 1,
+                                141: 2,
+                                142: 0,
+                                143: 0,
+                                144: 0,
+                                145: 0,
+                                146: 1,
+                                147: 0,
+                                148: 0,
+                                149: 0,
+                                150: 1,
+                                151: 2,
+                                152: 0,
+                                153: 0,
+                                154: 0,
+                                155: 0,
+                                156: 1,
+                                157: 0,
+                                158: 0,
+                                159: 0,
+                                160: 0,
+                                161: 0,
+                                162: 0,
+                                163: 0,
+                                164: 0,
+                                165: 0,
+                                166: 0,
+                                167: 0,
+                                168: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        3: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "indirectly_recursive_type",
+                },
+            ),
+        ),
+        4: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 270,
+                            edge_count: 275,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (7, 6), (8, 6), (9, 6), (6, 5), (10, 9), (11, 8), (13, 12), (12, 7), (15, 14), (16, 14), (17, 14), (14, 13), (18, 17), (19, 16), (21, 20), (20, 15), (23, 22), (24, 22), (25, 22), (22, 21), (26, 25), (27, 24), (29, 28), (28, 23), (31, 30), (32, 30), (33, 30), (30, 29), (34, 33), (35, 32), (37, 36), (36, 31), (39, 38), (40, 38), (41, 38), (38, 37), (42, 41), (43, 40), (45, 44), (44, 39), (47, 46), (48, 46), (49, 46), (46, 45), (50, 49), (51, 48), (53, 52), (52, 47), (55, 54), (56, 54), (57, 54), (54, 53), (58, 57), (59, 56), (61, 60), (60, 55), (63, 62), (64, 62), (65, 62), (62, 61), (66, 65), (67, 64), (69, 68), (68, 63), (71, 70), (72, 70), (73, 70), (70, 69), (74, 73), (75, 72), (77, 76), (76, 71), (79, 78), (80, 78), (81, 78), (78, 77), (82, 81), (83, 80), (85, 84), (84, 79), (87, 86), (88, 86), (89, 86), (86, 85), (90, 89), (91, 88), (93, 92), (87, 92), (95, 94), (96, 94), (97, 94), (94, 93), (98, 97), (99, 96), (101, 100), (95, 100), (103, 102), (104, 102), (105, 102), (102, 101), (106, 105), (107, 104), (109, 108), (103, 108), (111, 110), (112, 110), (113, 110), (110, 109), (114, 113), (115, 112), (117, 116), (111, 116), (119, 118), (120, 118), (121, 118), (118, 117), (122, 121), (123, 120), (125, 124), (119, 124), (87, 126), (127, 126), (128, 126), (126, 125), (129, 128), (130, 127), (132, 131), (133, 131), (134, 133), (95, 135), (136, 135), (137, 135), (135, 132), (138, 137), (139, 136), (141, 140), (142, 140), (144, 143), (145, 143), (143, 142), (146, 145), (148, 147), (147, 144), (95, 149), (150, 149), (151, 149), (149, 141), (152, 151), (153, 150), (155, 154), (156, 154), (157, 156), (103, 158), (159, 158), (160, 158), (158, 155), (161, 160), (162, 159), (164, 163), (165, 163), (167, 166), (168, 166), (166, 165), (169, 168), (148, 170), (170, 167), (103, 171), (172, 171), (173, 171), (171, 164), (174, 173), (175, 172), (177, 176), (178, 176), (179, 178), (111, 180), (181, 180), (182, 180), (180, 177), (183, 182), (184, 181), (186, 185), (187, 185), (189, 188), (190, 188), (188, 187), (191, 190), (148, 192), (192, 189), (111, 193), (194, 193), (195, 193), (193, 186), (196, 195), (197, 194), (199, 198), (200, 198), (201, 200), (119, 202), (203, 202), (204, 202), (202, 199), (205, 204), (206, 203), (208, 207), (209, 207), (211, 210), (212, 210), (210, 209), (213, 212), (148, 214), (214, 211), (119, 215), (216, 215), (217, 215), (215, 208), (218, 217), (219, 216), (221, 220), (222, 220), (224, 223), (225, 223), (223, 222), (226, 225), (221, 227), (227, 224), (87, 228), (229, 228), (230, 228), (228, 221), (231, 230), (232, 229), (234, 233), (235, 233), (236, 235), (87, 237), (238, 237), (239, 237), (237, 234), (240, 239), (241, 238), (243, 242), (244, 242), (148, 245), (245, 244), (87, 246), (247, 246), (248, 246), (246, 243), (249, 248), (250, 247), (148, 251), (0, 251), (253, 252), (252, 95), (254, 253), (256, 255), (255, 103), (257, 256), (259, 258), (258, 111), (260, 259), (262, 261), (261, 119), (263, 262), (265, 264), (264, 87), (266, 265), (268, 267), (267, 148), (269, 268),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            56,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                56,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        55,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    56,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                55,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        54,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    55,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                54,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        53,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    54,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                53,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        52,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    53,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                52,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        51,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    52,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                51,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                22: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        50,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    51,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                50,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                24: Edge(
+                                    Nil,
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                27: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        49,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    50,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                49,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                30: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        48,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    49,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                48,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Edge(
+                                    Nil,
+                                ),
+                                33: Edge(
+                                    Nil,
+                                ),
+                                34: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                35: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                36: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        47,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    48,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                37: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                47,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                38: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        46,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    47,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                39: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                46,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                40: Edge(
+                                    Nil,
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                43: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        45,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    46,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                45: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                45,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                46: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        44,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    45,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                47: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                44,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Edge(
+                                    Nil,
+                                ),
+                                50: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                51: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                52: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        43,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    44,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                53: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                43,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                54: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        42,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    43,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                42,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                56: Edge(
+                                    Nil,
+                                ),
+                                57: Edge(
+                                    Nil,
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        41,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    42,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                41,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                62: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        40,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    41,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                63: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                40,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                64: Edge(
+                                    Nil,
+                                ),
+                                65: Edge(
+                                    Nil,
+                                ),
+                                66: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                67: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                68: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        39,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    40,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                69: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                39,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                70: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        38,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    39,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                71: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                38,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                72: Edge(
+                                    Nil,
+                                ),
+                                73: Edge(
+                                    Nil,
+                                ),
+                                74: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                75: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                76: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        37,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    38,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                77: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                37,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                78: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        36,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    37,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                79: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                36,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                80: Edge(
+                                    Nil,
+                                ),
+                                81: Edge(
+                                    Nil,
+                                ),
+                                82: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                83: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                84: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        35,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    36,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                85: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                35,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                86: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    35,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                87: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                88: Edge(
+                                    Nil,
+                                ),
+                                89: Edge(
+                                    Nil,
+                                ),
+                                90: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                91: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                92: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        34,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                93: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                34,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                94: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    34,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                95: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                96: Edge(
+                                    Nil,
+                                ),
+                                97: Edge(
+                                    Nil,
+                                ),
+                                98: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                99: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                100: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        33,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                101: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                102: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    33,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                103: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                6,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                104: Edge(
+                                    Nil,
+                                ),
+                                105: Edge(
+                                    Nil,
+                                ),
+                                106: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                107: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                108: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        32,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                109: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                32,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                110: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    32,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                111: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                112: Edge(
+                                    Nil,
+                                ),
+                                113: Edge(
+                                    Nil,
+                                ),
+                                114: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                115: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                116: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        31,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                117: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                31,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                118: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    31,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                119: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                120: Edge(
+                                    Nil,
+                                ),
+                                121: Edge(
+                                    Nil,
+                                ),
+                                122: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                123: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                124: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        30,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                125: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                30,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                126: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    30,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                127: Edge(
+                                    Nil,
+                                ),
+                                128: Edge(
+                                    Nil,
+                                ),
+                                129: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                130: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                131: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        29,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                132: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                133: Edge(
+                                    Nil,
+                                ),
+                                134: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                135: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    29,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                136: Edge(
+                                    Nil,
+                                ),
+                                137: Edge(
+                                    Nil,
+                                ),
+                                138: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                139: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                140: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        28,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                141: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                26,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                142: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                28,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                143: Operation(
+                                    Instruction(
+                                        SDiv(
+                                            SDiv {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        27,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 100,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    28,
+                                                ),
+                                                exact: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                144: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                27,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                145: Edge(
+                                    Nil,
+                                ),
+                                146: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 100,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                147: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    27,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                148: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                2,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                149: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    26,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                150: Edge(
+                                    Nil,
+                                ),
+                                151: Edge(
+                                    Nil,
+                                ),
+                                152: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                153: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                154: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        25,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                155: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                25,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                156: Edge(
+                                    Nil,
+                                ),
+                                157: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                158: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    25,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                159: Edge(
+                                    Nil,
+                                ),
+                                160: Edge(
+                                    Nil,
+                                ),
+                                161: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                162: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                163: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        22,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        24,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                164: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                22,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                165: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                24,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                166: Operation(
+                                    Instruction(
+                                        SDiv(
+                                            SDiv {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        23,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    24,
+                                                ),
+                                                exact: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                167: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                23,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                168: Edge(
+                                    Nil,
+                                ),
+                                169: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                170: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    23,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                171: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    22,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                172: Edge(
+                                    Nil,
+                                ),
+                                173: Edge(
+                                    Nil,
+                                ),
+                                174: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                175: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                176: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                177: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                21,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                178: Edge(
+                                    Nil,
+                                ),
+                                179: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                180: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    21,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                181: Edge(
+                                    Nil,
+                                ),
+                                182: Edge(
+                                    Nil,
+                                ),
+                                183: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                184: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                185: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        18,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        20,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                186: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                18,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                187: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                20,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                188: Operation(
+                                    Instruction(
+                                        Mul(
+                                            Mul {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        19,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    20,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                189: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                19,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                190: Edge(
+                                    Nil,
+                                ),
+                                191: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                192: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    19,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                193: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    18,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                194: Edge(
+                                    Nil,
+                                ),
+                                195: Edge(
+                                    Nil,
+                                ),
+                                196: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                197: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                198: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                199: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                17,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                200: Edge(
+                                    Nil,
+                                ),
+                                201: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                202: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    17,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                203: Edge(
+                                    Nil,
+                                ),
+                                204: Edge(
+                                    Nil,
+                                ),
+                                205: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                206: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                207: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        14,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        16,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                208: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                209: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                16,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                210: Operation(
+                                    Instruction(
+                                        Sub(
+                                            Sub {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 3,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    16,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                211: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                212: Edge(
+                                    Nil,
+                                ),
+                                213: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                214: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                215: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                216: Edge(
+                                    Nil,
+                                ),
+                                217: Edge(
+                                    Nil,
+                                ),
+                                218: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                219: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                220: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                221: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                222: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                223: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                224: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                225: Edge(
+                                    Nil,
+                                ),
+                                226: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                227: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                228: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                229: Edge(
+                                    Nil,
+                                ),
+                                230: Edge(
+                                    Nil,
+                                ),
+                                231: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                232: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                233: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Null(
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                234: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                235: Edge(
+                                    Nil,
+                                ),
+                                236: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Null(
+                                                TypeRef(
+                                                    PointerType {
+                                                        addr_space: 0,
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                237: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                238: Edge(
+                                    Nil,
+                                ),
+                                239: Edge(
+                                    Nil,
+                                ),
+                                240: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                241: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                242: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                243: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                244: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                245: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                246: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                247: Edge(
+                                    Nil,
+                                ),
+                                248: Edge(
+                                    Nil,
+                                ),
+                                249: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                250: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                251: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        2,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: false,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                252: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                253: Edge(
+                                    Nil,
+                                ),
+                                254: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                255: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    6,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                256: Edge(
+                                    Nil,
+                                ),
+                                257: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                258: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                259: Edge(
+                                    Nil,
+                                ),
+                                260: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                261: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                262: Edge(
+                                    Nil,
+                                ),
+                                263: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                264: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    NamedStructType {
+                                                        name: "struct.SimpleLinkedList",
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 8,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                265: Edge(
+                                    Nil,
+                                ),
+                                266: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                267: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    2,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                268: Edge(
+                                    Nil,
+                                ),
+                                269: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 1,
+                                6: 2,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 0,
+                                11: 0,
+                                12: 0,
+                                13: 1,
+                                14: 2,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 1,
+                                22: 2,
+                                23: 0,
+                                24: 0,
+                                25: 0,
+                                26: 0,
+                                27: 0,
+                                28: 0,
+                                29: 1,
+                                30: 2,
+                                31: 0,
+                                32: 0,
+                                33: 0,
+                                34: 0,
+                                35: 0,
+                                36: 0,
+                                37: 1,
+                                38: 2,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 0,
+                                44: 0,
+                                45: 1,
+                                46: 2,
+                                47: 0,
+                                48: 0,
+                                49: 0,
+                                50: 0,
+                                51: 0,
+                                52: 0,
+                                53: 1,
+                                54: 2,
+                                55: 0,
+                                56: 0,
+                                57: 0,
+                                58: 0,
+                                59: 0,
+                                60: 0,
+                                61: 1,
+                                62: 2,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 0,
+                                68: 0,
+                                69: 1,
+                                70: 2,
+                                71: 0,
+                                72: 0,
+                                73: 0,
+                                74: 0,
+                                75: 0,
+                                76: 0,
+                                77: 1,
+                                78: 2,
+                                79: 0,
+                                80: 0,
+                                81: 0,
+                                82: 0,
+                                83: 0,
+                                84: 0,
+                                85: 1,
+                                86: 2,
+                                87: 0,
+                                88: 0,
+                                89: 0,
+                                90: 0,
+                                91: 1,
+                                92: 0,
+                                93: 1,
+                                94: 2,
+                                95: 0,
+                                96: 0,
+                                97: 0,
+                                98: 0,
+                                99: 1,
+                                100: 0,
+                                101: 1,
+                                102: 2,
+                                103: 0,
+                                104: 0,
+                                105: 0,
+                                106: 0,
+                                107: 1,
+                                108: 0,
+                                109: 1,
+                                110: 2,
+                                111: 0,
+                                112: 0,
+                                113: 0,
+                                114: 0,
+                                115: 1,
+                                116: 0,
+                                117: 1,
+                                118: 2,
+                                119: 0,
+                                120: 0,
+                                121: 0,
+                                122: 0,
+                                123: 1,
+                                124: 0,
+                                125: 1,
+                                126: 2,
+                                127: 0,
+                                128: 0,
+                                129: 0,
+                                130: 0,
+                                131: 1,
+                                132: 0,
+                                133: 0,
+                                134: 1,
+                                135: 2,
+                                136: 0,
+                                137: 0,
+                                138: 0,
+                                139: 0,
+                                140: 1,
+                                141: 0,
+                                142: 1,
+                                143: 0,
+                                144: 0,
+                                145: 0,
+                                146: 0,
+                                147: 0,
+                                148: 1,
+                                149: 2,
+                                150: 0,
+                                151: 0,
+                                152: 0,
+                                153: 0,
+                                154: 1,
+                                155: 0,
+                                156: 0,
+                                157: 1,
+                                158: 2,
+                                159: 0,
+                                160: 0,
+                                161: 0,
+                                162: 0,
+                                163: 1,
+                                164: 0,
+                                165: 1,
+                                166: 0,
+                                167: 0,
+                                168: 0,
+                                169: 0,
+                                170: 0,
+                                171: 1,
+                                172: 2,
+                                173: 0,
+                                174: 0,
+                                175: 0,
+                                176: 0,
+                                177: 1,
+                                178: 0,
+                                179: 0,
+                                180: 1,
+                                181: 2,
+                                182: 0,
+                                183: 0,
+                                184: 0,
+                                185: 0,
+                                186: 1,
+                                187: 0,
+                                188: 1,
+                                189: 0,
+                                190: 0,
+                                191: 0,
+                                192: 0,
+                                193: 0,
+                                194: 1,
+                                195: 2,
+                                196: 0,
+                                197: 0,
+                                198: 0,
+                                199: 0,
+                                200: 1,
+                                201: 0,
+                                202: 0,
+                                203: 1,
+                                204: 2,
+                                205: 0,
+                                206: 0,
+                                207: 0,
+                                208: 0,
+                                209: 1,
+                                210: 0,
+                                211: 1,
+                                212: 0,
+                                213: 0,
+                                214: 0,
+                                215: 0,
+                                216: 0,
+                                217: 1,
+                                218: 2,
+                                219: 0,
+                                220: 0,
+                                221: 0,
+                                222: 0,
+                                223: 1,
+                                224: 0,
+                                225: 1,
+                                226: 0,
+                                227: 0,
+                                228: 0,
+                                229: 0,
+                                230: 0,
+                                231: 1,
+                                232: 2,
+                                233: 0,
+                                234: 0,
+                                235: 0,
+                                236: 0,
+                                237: 1,
+                                238: 0,
+                                239: 0,
+                                240: 1,
+                                241: 2,
+                                242: 0,
+                                243: 0,
+                                244: 0,
+                                245: 0,
+                                246: 1,
+                                247: 0,
+                                248: 0,
+                                249: 0,
+                                250: 1,
+                                251: 2,
+                                252: 0,
+                                253: 0,
+                                254: 0,
+                                255: 0,
+                                256: 1,
+                                257: 0,
+                                258: 0,
+                                259: 0,
+                                260: 0,
+                                261: 0,
+                                262: 0,
+                                263: 0,
+                                264: 0,
+                                265: 0,
+                                266: 0,
+                                267: 0,
+                                268: 0,
+                                269: 0,
+                                270: 0,
+                                271: 0,
+                                272: 0,
+                                273: 0,
+                                274: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        5: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "simple_linked_list",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+        2: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_loop_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_loop_debug.llvm-ir.snap
@@ -1,0 +1,3603 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 5,
+    edge_count: 4,
+    edges: (2, 3), (1, 3), (0, 3), (3, 4),
+    node weights: {
+        0: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "llvm.lifetime.start.p0",
+                },
+            ),
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "llvm.memset.p0.i64",
+                },
+            ),
+        ),
+        2: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "llvm.lifetime.end.p0",
+                },
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 33,
+                edge_count: 52,
+                edges: (6, 5), (0, 5), (7, 5), (8, 5), (9, 5), (10, 5), (5, 11), (4, 12), (6, 12), (13, 12), (14, 12), (15, 12), (12, 10), (17, 16), (18, 16), (19, 16), (20, 16), (16, 9), (16, 15), (16, 13), (22, 21), (4, 21), (6, 21), (14, 21), (23, 21), (24, 21), (21, 20), (21, 24), (21, 18), (26, 25), (27, 25), (25, 23), (25, 22), (4, 28), (29, 28), (28, 19), (28, 27), (28, 17), (28, 26), (4, 30), (6, 30), (3, 30), (31, 30), (30, 8), (30, 29), (30, 14), (4, 32), (1, 32), (2, 32), (32, 31), (32, 7), (32, 6),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "llvm.lifetime.end.p0",
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "llvm.memset.p0.i64",
+                            },
+                        ),
+                    ),
+                    2: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "llvm.lifetime.start.p0",
+                            },
+                        ),
+                    ),
+                    3: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    4: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    1,
+                                ),
+                            },
+                        ),
+                    ),
+                    5: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 9,
+                            edge_count: 7,
+                            edges: (2, 3), (5, 4), (6, 4), (0, 4), (7, 6), (1, 8), (8, 5),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "llvm.lifetime.end.p0",
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: None,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.end.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 40,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                3,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [
+                                                    NoUnwind,
+                                                ],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 40,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.end.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 2,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                            },
+                        },
+                    ),
+                    6: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    3,
+                                ),
+                            },
+                        ),
+                    ),
+                    7: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    8: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    9: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    10: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    41,
+                                ),
+                            ),
+                        ),
+                    ),
+                    11: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    12: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 24,
+                            edge_count: 24,
+                            edges: (4, 5), (7, 6), (8, 6), (10, 9), (0, 9), (9, 8), (7, 11), (11, 10), (1, 12), (13, 12), (14, 12), (12, 7), (15, 13), (2, 16), (17, 16), (16, 14), (18, 17), (20, 19), (3, 19), (1, 21), (22, 21), (2, 21), (21, 20), (23, 22),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    41,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        38,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        40,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                38,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                40,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                9: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        39,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    40,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                39,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        38,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    39,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            37,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    38,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    Nil,
+                                ),
+                                14: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                37,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                15: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        33,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551615,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    37,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551615,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        36,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                36,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                21: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            33,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    36,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Edge(
+                                    Nil,
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 1,
+                                10: 2,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 1,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 1,
+                                19: 0,
+                                20: 1,
+                                21: 2,
+                                22: 0,
+                                23: 0,
+                            },
+                        },
+                    ),
+                    13: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    33,
+                                ),
+                            },
+                        ),
+                    ),
+                    14: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    7,
+                                ),
+                            },
+                        ),
+                    ),
+                    15: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    35,
+                                ),
+                            ),
+                        ),
+                    ),
+                    16: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 15,
+                            edge_count: 13,
+                            edges: (3, 2), (2, 4), (2, 5), (7, 6), (0, 6), (8, 6), (6, 3), (9, 8), (10, 7), (12, 11), (1, 11), (11, 13), (14, 12),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        34,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    41,
+                                                ),
+                                                false_dest: Number(
+                                                    35,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                34,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                35,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 0,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    34,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                10: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                11: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                29,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        },
+                                                        Number(
+                                                            16,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    33,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                33,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                            },
+                        },
+                    ),
+                    17: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    12,
+                                ),
+                            },
+                        ),
+                    ),
+                    18: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    29,
+                                ),
+                            },
+                        ),
+                    ),
+                    19: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    32,
+                                ),
+                            ),
+                        ),
+                    ),
+                    20: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    32,
+                                ),
+                            ),
+                        ),
+                    ),
+                    21: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 63,
+                            edge_count: 70,
+                            edges: (5, 4), (4, 6), (4, 7), (9, 8), (10, 8), (0, 8), (8, 5), (11, 9), (13, 12), (14, 12), (12, 10), (16, 15), (10, 15), (15, 13), (17, 14), (19, 18), (20, 18), (22, 21), (1, 21), (21, 20), (19, 23), (23, 22), (2, 24), (25, 24), (26, 24), (24, 19), (28, 27), (3, 27), (2, 29), (30, 29), (31, 29), (29, 28), (26, 32), (33, 32), (32, 31), (35, 34), (36, 34), (38, 37), (1, 37), (37, 36), (35, 39), (39, 38), (2, 40), (41, 40), (42, 40), (40, 35), (26, 43), (44, 43), (43, 42), (46, 45), (3, 45), (2, 47), (48, 47), (26, 47), (47, 46), (26, 49), (50, 49), (49, 51), (53, 52), (51, 52), (52, 26), (54, 50), (55, 25), (56, 30), (57, 33), (58, 41), (59, 44), (60, 48), (61, 16), (62, 53),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                4: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        31,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    32,
+                                                ),
+                                                false_dest: Number(
+                                                    16,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                31,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                32,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                16,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                8: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        30,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    31,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                30,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                11: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        18,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    30,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                18,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            14,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                30,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        },
+                                                        Number(
+                                                            16,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    18,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        28,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                26,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                20: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                28,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                21: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        27,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    28,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                27,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                23: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        26,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    27,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            17,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    26,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Edge(
+                                    Nil,
+                                ),
+                                26: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                17,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                27: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        25,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                25,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                29: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            24,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    25,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                30: Edge(
+                                    Nil,
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                24,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    24,
+                                                ),
+                                                nuw: true,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                33: Edge(
+                                    Nil,
+                                ),
+                                34: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        23,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                35: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                21,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                36: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                23,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                37: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        22,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    23,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                38: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                22,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                39: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        21,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    22,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                40: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            20,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    21,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                41: Edge(
+                                    Nil,
+                                ),
+                                42: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                20,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                43: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551615,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    20,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Edge(
+                                    Nil,
+                                ),
+                                45: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        19,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                46: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                19,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                47: Operation(
+                                    Instruction(
+                                        GetElementPtr(
+                                            GetElementPtr {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                indices: [
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 64,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            17,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 64,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                                dest: Number(
+                                                    19,
+                                                ),
+                                                in_bounds: true,
+                                                debugloc: None,
+                                                source_element_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                48: Edge(
+                                    Nil,
+                                ),
+                                49: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        17,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    29,
+                                                ),
+                                                nuw: true,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                50: Edge(
+                                    Nil,
+                                ),
+                                51: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                29,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                52: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            14,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                29,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        },
+                                                        Number(
+                                                            16,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    17,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                53: Edge(
+                                    Nil,
+                                ),
+                                54: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                56: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                57: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551615,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                62: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 1,
+                                10: 0,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 1,
+                                17: 0,
+                                18: 1,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 1,
+                                24: 2,
+                                25: 0,
+                                26: 0,
+                                27: 1,
+                                28: 0,
+                                29: 1,
+                                30: 2,
+                                31: 0,
+                                32: 0,
+                                33: 1,
+                                34: 0,
+                                35: 0,
+                                36: 1,
+                                37: 0,
+                                38: 1,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 1,
+                                44: 2,
+                                45: 0,
+                                46: 0,
+                                47: 1,
+                                48: 0,
+                                49: 0,
+                                50: 1,
+                                51: 0,
+                                52: 1,
+                                53: 2,
+                                54: 0,
+                                55: 0,
+                                56: 1,
+                                57: 0,
+                                58: 0,
+                                59: 1,
+                                60: 0,
+                                61: 0,
+                                62: 0,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 0,
+                                68: 0,
+                                69: 0,
+                            },
+                        },
+                    ),
+                    22: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    15,
+                                ),
+                            },
+                        ),
+                    ),
+                    23: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    16,
+                                ),
+                            ),
+                        ),
+                    ),
+                    24: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    16,
+                                ),
+                            ),
+                        ),
+                    ),
+                    25: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 5,
+                            edges: (1, 2), (0, 3), (4, 3), (3, 5), (6, 4),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    16,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                16,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                3: Operation(
+                                    Instruction(
+                                        And(
+                                            And {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551614,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    Nil,
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551614,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 0,
+                            },
+                        },
+                    ),
+                    26: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    11,
+                                ),
+                            },
+                        ),
+                    ),
+                    27: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    14,
+                                ),
+                            ),
+                        ),
+                    ),
+                    28: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 20,
+                            edge_count: 19,
+                            edges: (2, 1), (1, 3), (1, 4), (6, 5), (0, 5), (7, 5), (5, 2), (8, 7), (9, 6), (11, 10), (12, 10), (10, 13), (14, 12), (16, 15), (17, 15), (15, 11), (18, 17), (0, 19), (19, 16),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    32,
+                                                ),
+                                                false_dest: Number(
+                                                    14,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                32,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                14,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 2,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 2,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                10: Operation(
+                                    Instruction(
+                                        And(
+                                            And {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 64,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 64,
+                                                            value: 18446744073709551615,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 18446744073709551615,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Instruction(
+                                        ZExt(
+                                            ZExt {
+                                                operand: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 64,
+                                                    },
+                                                ),
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 1,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                            },
+                        },
+                    ),
+                    29: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    9,
+                                ),
+                            ),
+                        ),
+                    ),
+                    30: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 17,
+                            edge_count: 15,
+                            edges: (4, 3), (3, 5), (3, 6), (8, 7), (0, 7), (9, 7), (7, 4), (10, 9), (11, 8), (1, 12), (13, 12), (2, 14), (15, 14), (14, 13), (16, 15),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    41,
+                                                ),
+                                                false_dest: Number(
+                                                    9,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                9,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: EQ,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                11: Operation(
+                                    IntPredicate(
+                                        EQ,
+                                    ),
+                                ),
+                                12: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 16,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 3,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 1,
+                                13: 0,
+                                14: 0,
+                            },
+                        },
+                    ),
+                    31: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    6,
+                                ),
+                            ),
+                        ),
+                    ),
+                    32: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 34,
+                            edge_count: 32,
+                            edges: (4, 3), (3, 5), (3, 6), (8, 7), (9, 7), (10, 7), (7, 4), (11, 10), (12, 8), (0, 13), (14, 13), (13, 9), (15, 14), (17, 16), (18, 16), (19, 16), (20, 16), (21, 16), (22, 21), (23, 20), (24, 19), (1, 25), (25, 17), (27, 26), (28, 26), (18, 26), (29, 28), (2, 30), (30, 27), (32, 31), (31, 18), (33, 32),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "llvm.memset.p0.i64",
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "llvm.lifetime.start.p0",
+                                        },
+                                    ),
+                                ),
+                                3: Operation(
+                                    Terminator(
+                                        CondBr(
+                                            CondBr {
+                                                condition: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 1,
+                                                        },
+                                                    ),
+                                                },
+                                                true_dest: Number(
+                                                    6,
+                                                ),
+                                                false_dest: Number(
+                                                    41,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                6,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                41,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Operation(
+                                    Instruction(
+                                        ICmp(
+                                            ICmp {
+                                                predicate: ULT,
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 10,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    5,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                10: Edge(
+                                    Nil,
+                                ),
+                                11: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 10,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                12: Operation(
+                                    IntPredicate(
+                                        ULT,
+                                    ),
+                                ),
+                                13: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 4294967295,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                nuw: false,
+                                                nsw: false,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967295,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                16: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.memset.p0.i64",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 8,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 1,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 8,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 1,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                3,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                            Alignment(
+                                                                16,
+                                                            ),
+                                                        ],
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 8,
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 40,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 1,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Edge(
+                                    Nil,
+                                ),
+                                18: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                19: Edge(
+                                    Nil,
+                                ),
+                                20: Edge(
+                                    Nil,
+                                ),
+                                21: Edge(
+                                    Nil,
+                                ),
+                                22: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 1,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 40,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 8,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.memset.p0.i64",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 8,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 1,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                26: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.start.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 40,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                3,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [
+                                                    NoUnwind,
+                                                ],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                27: Edge(
+                                    Nil,
+                                ),
+                                28: Edge(
+                                    Nil,
+                                ),
+                                29: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 40,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                30: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.start.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                31: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        num_elements: 10,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 16,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                32: Edge(
+                                    Nil,
+                                ),
+                                33: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 1,
+                                5: 2,
+                                6: 0,
+                                7: 0,
+                                8: 0,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 1,
+                                15: 2,
+                                16: 3,
+                                17: 4,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 0,
+                                24: 1,
+                                25: 2,
+                                26: 0,
+                                27: 0,
+                                28: 0,
+                                29: 0,
+                                30: 0,
+                                31: 0,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 3,
+                    4: 4,
+                    5: 5,
+                    6: 0,
+                    7: 0,
+                    8: 1,
+                    9: 2,
+                    10: 3,
+                    11: 4,
+                    12: 0,
+                    13: 0,
+                    14: 1,
+                    15: 2,
+                    16: 3,
+                    17: 0,
+                    18: 1,
+                    19: 2,
+                    20: 0,
+                    21: 1,
+                    22: 2,
+                    23: 3,
+                    24: 4,
+                    25: 5,
+                    26: 0,
+                    27: 1,
+                    28: 2,
+                    29: 0,
+                    30: 1,
+                    31: 0,
+                    32: 1,
+                    33: 0,
+                    34: 1,
+                    35: 0,
+                    36: 1,
+                    37: 2,
+                    38: 3,
+                    39: 0,
+                    40: 1,
+                    41: 2,
+                    42: 3,
+                    43: 0,
+                    44: 1,
+                    45: 2,
+                    46: 0,
+                    47: 1,
+                    48: 2,
+                    49: 0,
+                    50: 1,
+                    51: 2,
+                },
+            },
+        ),
+        4: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "loop",
+                },
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 1,
+        2: 2,
+        3: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_mutual_diverge_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_mutual_diverge_debug.llvm-ir.snap
@@ -1,0 +1,358 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 4,
+    edge_count: 4,
+    edges: (1, 0), (0, 2), (2, 3), (3, 1),
+    node weights: {
+        0: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "diverge1",
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (0, 6), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "diverge1",
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "diverge1",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "diverge1",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "diverge1",
+                },
+            ),
+        ),
+        2: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "diverge2",
+                },
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 3,
+                edge_count: 2,
+                edges: (0, 1), (1, 2),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "diverge2",
+                            },
+                        ),
+                    ),
+                    1: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 7,
+                            edge_count: 6,
+                            edges: (2, 1), (1, 3), (5, 4), (4, 2), (0, 6), (6, 5),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "diverge2",
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Name(
+                                                            "tmp1",
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Name(
+                                                "tmp1",
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "diverge2",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Name(
+                                                        "tmp1",
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "diverge2",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 0,
+                                4: 0,
+                                5: 0,
+                            },
+                        },
+                    ),
+                    2: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 0,
+                },
+            },
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_switch_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_switch_debug.llvm-ir.snap
@@ -1,0 +1,1677 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 7,
+    edge_count: 6,
+    edges: (2, 1), (0, 1), (1, 3), (5, 4), (4, 2), (6, 5),
+    node weights: {
+        0: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "puts",
+                },
+            ),
+        ),
+        1: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 34,
+                edge_count: 43,
+                edges: (2, 3), (4, 3), (5, 3), (6, 3), (7, 3), (8, 3), (9, 3), (10, 3), (11, 3), (12, 3), (13, 3), (3, 14), (0, 15), (1, 15), (16, 15), (15, 13), (18, 17), (17, 12), (20, 19), (19, 11), (22, 21), (21, 10), (24, 23), (23, 9), (26, 25), (25, 8), (28, 27), (27, 7), (30, 29), (29, 6), (32, 31), (31, 5), (2, 33), (33, 4), (33, 32), (33, 30), (33, 28), (33, 26), (33, 24), (33, 22), (33, 20), (33, 18), (33, 16),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "str",
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "puts",
+                            },
+                        ),
+                    ),
+                    2: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    3: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 27,
+                            edge_count: 26,
+                            edges: (2, 1), (1, 3), (5, 4), (0, 4), (4, 2), (7, 6), (8, 6), (9, 6), (10, 6), (11, 6), (12, 6), (13, 6), (14, 6), (15, 6), (16, 6), (6, 5), (17, 16), (18, 15), (19, 14), (20, 13), (21, 12), (22, 11), (23, 10), (24, 9), (25, 8), (26, 7),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: Some(
+                                                    LocalOperand {
+                                                        name: Number(
+                                                            14,
+                                                        ),
+                                                        ty: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Instruction(
+                                        Phi(
+                                            Phi {
+                                                incoming_values: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967295,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            10,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967293,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 0,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            8,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 77,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            7,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967263,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            6,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 1,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            5,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967291,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            4,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 4294967289,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            3,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 5,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            2,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 32,
+                                                                    value: 3,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        Number(
+                                                            1,
+                                                        ),
+                                                    ),
+                                                ],
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                to_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    Nil,
+                                ),
+                                8: Edge(
+                                    Nil,
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Edge(
+                                    Nil,
+                                ),
+                                11: Edge(
+                                    Nil,
+                                ),
+                                12: Edge(
+                                    Nil,
+                                ),
+                                13: Edge(
+                                    Nil,
+                                ),
+                                14: Edge(
+                                    Nil,
+                                ),
+                                15: Edge(
+                                    Nil,
+                                ),
+                                16: Edge(
+                                    Nil,
+                                ),
+                                17: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 3,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                18: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967289,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967291,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967263,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                23: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 77,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                24: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 0,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967293,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                26: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 4294967295,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 0,
+                                3: 1,
+                                4: 0,
+                                5: 0,
+                                6: 1,
+                                7: 2,
+                                8: 3,
+                                9: 4,
+                                10: 5,
+                                11: 6,
+                                12: 7,
+                                13: 8,
+                                14: 9,
+                                15: 0,
+                                16: 0,
+                                17: 0,
+                                18: 0,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 0,
+                                24: 0,
+                                25: 0,
+                            },
+                        },
+                    ),
+                    4: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    5: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    6: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    7: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    8: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    9: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    10: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    11: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    12: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    13: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    12,
+                                ),
+                            ),
+                        ),
+                    ),
+                    14: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                    15: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 10,
+                            edge_count: 8,
+                            edges: (2, 3), (5, 4), (6, 4), (4, 7), (0, 8), (8, 6), (1, 9), (9, 5),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "str",
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "puts",
+                                        },
+                                    ),
+                                ),
+                                2: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "puts",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            IntegerType {
+                                                                                bits: 32,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                GlobalReference {
+                                                                    name: Name(
+                                                                        "str",
+                                                                    ),
+                                                                    ty: TypeRef(
+                                                                        ArrayType {
+                                                                            element_type: TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 8,
+                                                                                },
+                                                                            ),
+                                                                            num_elements: 16,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [
+                                                            NonNull,
+                                                            Dereferenceable(
+                                                                1,
+                                                            ),
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: Some(
+                                                    Number(
+                                                        11,
+                                                    ),
+                                                ),
+                                                function_attributes: [],
+                                                is_tail_call: true,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    Nil,
+                                ),
+                                6: Edge(
+                                    Nil,
+                                ),
+                                7: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                8: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "str",
+                                                ),
+                                                ty: TypeRef(
+                                                    ArrayType {
+                                                        element_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 8,
+                                                            },
+                                                        ),
+                                                        num_elements: 16,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "puts",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            IntegerType {
+                                                                bits: 32,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 0,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                            },
+                        },
+                    ),
+                    16: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    10,
+                                ),
+                            ),
+                        ),
+                    ),
+                    17: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    18: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    9,
+                                ),
+                            ),
+                        ),
+                    ),
+                    19: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    20: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    8,
+                                ),
+                            ),
+                        ),
+                    ),
+                    21: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    22: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    7,
+                                ),
+                            ),
+                        ),
+                    ),
+                    23: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    24: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    6,
+                                ),
+                            ),
+                        ),
+                    ),
+                    25: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    26: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    5,
+                                ),
+                            ),
+                        ),
+                    ),
+                    27: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    28: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    4,
+                                ),
+                            ),
+                        ),
+                    ),
+                    29: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    30: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    3,
+                                ),
+                            ),
+                        ),
+                    ),
+                    31: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 2,
+                            edge_count: 1,
+                            edges: (0, 1),
+                            node weights: {
+                                0: Operation(
+                                    Terminator(
+                                        Br(
+                                            Br {
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                1: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                            },
+                        },
+                    ),
+                    32: Edge(
+                        CF(
+                            Some(
+                                Number(
+                                    2,
+                                ),
+                            ),
+                        ),
+                    ),
+                    33: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 12,
+                            edge_count: 11,
+                            edges: (0, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8), (1, 9), (1, 10), (1, 11),
+                            node weights: {
+                                0: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                1: Operation(
+                                    Terminator(
+                                        Switch(
+                                            Switch {
+                                                operand: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                dests: [
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 0,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            12,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            2,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 13,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            3,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 26,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            4,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 33,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            5,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 142,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            6,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 1678,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            7,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 88,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            8,
+                                                        ),
+                                                    ),
+                                                    (
+                                                        ConstantRef(
+                                                            Int {
+                                                                bits: 32,
+                                                                value: 101,
+                                                            },
+                                                        ),
+                                                        Number(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                ],
+                                                default_dest: Number(
+                                                    10,
+                                                ),
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                2: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                12,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                3: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                2,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                4: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                3,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                5: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                4,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                6: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                5,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                6,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                8: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                7,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                9: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                8,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                10: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                9,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                11: Edge(
+                                    CF(
+                                        Some(
+                                            Number(
+                                                10,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 2,
+                                4: 3,
+                                5: 4,
+                                6: 5,
+                                7: 6,
+                                8: 7,
+                                9: 8,
+                                10: 9,
+                            },
+                        },
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 3,
+                    4: 4,
+                    5: 5,
+                    6: 6,
+                    7: 7,
+                    8: 8,
+                    9: 9,
+                    10: 10,
+                    11: 0,
+                    12: 0,
+                    13: 1,
+                    14: 2,
+                    15: 0,
+                    16: 0,
+                    17: 0,
+                    18: 0,
+                    19: 0,
+                    20: 0,
+                    21: 0,
+                    22: 0,
+                    23: 0,
+                    24: 0,
+                    25: 0,
+                    26: 0,
+                    27: 0,
+                    28: 0,
+                    29: 0,
+                    30: 0,
+                    31: 0,
+                    32: 0,
+                    33: 0,
+                    34: 1,
+                    35: 2,
+                    36: 3,
+                    37: 4,
+                    38: 5,
+                    39: 6,
+                    40: 7,
+                    41: 8,
+                    42: 9,
+                },
+            },
+        ),
+        2: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "str",
+                },
+            ),
+        ),
+        3: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "has_a_switch",
+                },
+            ),
+        ),
+        4: Operation(
+            GlobalVariable(
+                GlobalVariable {
+                    name: Name(
+                        "str",
+                    ),
+                    linkage: Private,
+                    visibility: Default,
+                    is_constant: true,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    addr_space: 0,
+                    dll_storage_class: Default,
+                    thread_local_mode: NotThreadLocal,
+                    unnamed_addr: Some(
+                        Global,
+                    ),
+                    initializer: Some(
+                        ConstantRef(
+                            Array {
+                                element_type: TypeRef(
+                                    IntegerType {
+                                        bits: 8,
+                                    },
+                                ),
+                                elements: [
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 114,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 101,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 97,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 99,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 104,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 101,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 100,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 32,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 100,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 101,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 102,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 97,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 117,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 108,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 116,
+                                        },
+                                    ),
+                                    ConstantRef(
+                                        Int {
+                                            bits: 8,
+                                            value: 0,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ),
+                    section: None,
+                    comdat: None,
+                    alignment: 1,
+                    debugloc: None,
+                },
+            ),
+        ),
+        5: Edge(
+            Nil,
+        ),
+        6: Operation(
+            Constant(
+                ConstantRef(
+                    Array {
+                        element_type: TypeRef(
+                            IntegerType {
+                                bits: 8,
+                            },
+                        ),
+                        elements: [
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 114,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 101,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 97,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 99,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 104,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 101,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 100,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 32,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 100,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 101,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 102,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 97,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 117,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 108,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 116,
+                                },
+                            ),
+                            ConstantRef(
+                                Int {
+                                    bits: 8,
+                                    value: 0,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 1,
+        2: 0,
+        3: 0,
+        4: 0,
+        5: 0,
+    },
+}

--- a/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_variables_debug.llvm-ir.snap
+++ b/sd-core/src/language/snapshots/sd_core__language__tests__hypergraph_with_sym_variables_debug.llvm-ir.snap
@@ -1,0 +1,1582 @@
+---
+source: sd-core/src/language/mod.rs
+expression: to_pet(&graph)
+---
+Graph {
+    Ty: "Directed",
+    node_count: 9,
+    edge_count: 8,
+    edges: (2, 3), (4, 3), (1, 3), (0, 3), (3, 5), (7, 6), (6, 4), (8, 7),
+    node weights: {
+        0: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "llvm.lifetime.start.p0",
+                },
+            ),
+        ),
+        1: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "malloc",
+                },
+            ),
+        ),
+        2: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "llvm.lifetime.end.p0",
+                },
+            ),
+        ),
+        3: Thunk(
+            Graph {
+                Ty: "Directed",
+                node_count: 8,
+                edge_count: 7,
+                edges: (0, 6), (5, 6), (1, 6), (2, 6), (3, 6), (4, 6), (6, 7),
+                node weights: {
+                    0: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "llvm.lifetime.end.p0",
+                            },
+                        ),
+                    ),
+                    1: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "global",
+                            },
+                        ),
+                    ),
+                    2: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "malloc",
+                            },
+                        ),
+                    ),
+                    3: Edge(
+                        FreeVar(
+                            Symbol {
+                                symbol: "llvm.lifetime.start.p0",
+                            },
+                        ),
+                    ),
+                    4: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                    5: Edge(
+                        BoundVar(
+                            Var {
+                                name: Number(
+                                    1,
+                                ),
+                            },
+                        ),
+                    ),
+                    6: Thunk(
+                        Graph {
+                            Ty: "Directed",
+                            node_count: 75,
+                            edge_count: 74,
+                            edges: (6, 7), (9, 8), (10, 8), (11, 8), (12, 10), (0, 13), (13, 9), (1, 14), (15, 14), (17, 16), (18, 16), (16, 15), (19, 18), (1, 20), (20, 17), (22, 21), (23, 21), (25, 24), (26, 24), (24, 23), (27, 26), (22, 28), (28, 25), (30, 29), (31, 29), (2, 32), (32, 30), (34, 33), (35, 33), (33, 31), (36, 35), (38, 37), (37, 34), (2, 39), (39, 38), (41, 40), (42, 40), (44, 43), (45, 43), (43, 42), (46, 45), (41, 47), (47, 44), (11, 48), (49, 48), (51, 50), (52, 50), (50, 49), (53, 52), (11, 54), (54, 51), (56, 55), (57, 55), (55, 41), (58, 57), (3, 59), (59, 56), (11, 60), (61, 60), (62, 61), (64, 63), (65, 63), (11, 63), (66, 65), (4, 67), (67, 64), (22, 68), (5, 68), (70, 69), (69, 11), (71, 70), (73, 72), (72, 22), (74, 73),
+                            node weights: {
+                                0: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "llvm.lifetime.end.p0",
+                                        },
+                                    ),
+                                ),
+                                1: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                2: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "global",
+                                        },
+                                    ),
+                                ),
+                                3: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "malloc",
+                                        },
+                                    ),
+                                ),
+                                4: Edge(
+                                    FreeVar(
+                                        Symbol {
+                                            symbol: "llvm.lifetime.start.p0",
+                                        },
+                                    ),
+                                ),
+                                5: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                0,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                6: Operation(
+                                    Terminator(
+                                        Ret(
+                                            Ret {
+                                                return_operand: None,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                7: Edge(
+                                    CF(
+                                        None,
+                                    ),
+                                ),
+                                8: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.end.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 4,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                4,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                9: Edge(
+                                    Nil,
+                                ),
+                                10: Edge(
+                                    Nil,
+                                ),
+                                11: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                4,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                12: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                13: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.end.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                14: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        15,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                15: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                15,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                16: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        14,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    15,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                17: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                14,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                18: Edge(
+                                    Nil,
+                                ),
+                                19: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                20: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        1,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    14,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                21: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        13,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                22: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                3,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                23: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                13,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                24: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        12,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    13,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                25: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                12,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                26: Edge(
+                                    Nil,
+                                ),
+                                27: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                28: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    12,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                29: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "global",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        11,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                30: Edge(
+                                    Nil,
+                                ),
+                                31: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                11,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                32: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "global",
+                                                ),
+                                                ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                33: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        10,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    11,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                34: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                10,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                35: Edge(
+                                    Nil,
+                                ),
+                                36: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                37: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: ConstantOperand(
+                                                    ConstantRef(
+                                                        GlobalReference {
+                                                            name: Name(
+                                                                "global",
+                                                            ),
+                                                            ty: TypeRef(
+                                                                IntegerType {
+                                                                    bits: 32,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    10,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                38: Edge(
+                                    Nil,
+                                ),
+                                39: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "global",
+                                                ),
+                                                ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                40: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        9,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                41: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                5,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                42: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                9,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                43: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        8,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    9,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                44: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                8,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                45: Edge(
+                                    Nil,
+                                ),
+                                46: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                47: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        5,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    8,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                48: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        7,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                49: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                7,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                50: Operation(
+                                    Instruction(
+                                        Add(
+                                            Add {
+                                                operand0: LocalOperand {
+                                                    name: Number(
+                                                        6,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                operand1: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 5,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    7,
+                                                ),
+                                                nuw: false,
+                                                nsw: true,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                51: Edge(
+                                    BoundVar(
+                                        Var {
+                                            name: Number(
+                                                6,
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                52: Edge(
+                                    Nil,
+                                ),
+                                53: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 5,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                54: Operation(
+                                    Instruction(
+                                        Load(
+                                            Load {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                dest: Number(
+                                                    6,
+                                                ),
+                                                loaded_ty: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                55: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "malloc",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            PointerType {
+                                                                                addr_space: 0,
+                                                                            },
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            PointerType {
+                                                                addr_space: 0,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 4,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [
+                                                            NoUndef,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [
+                                                    DereferenceableOrNull(
+                                                        4,
+                                                    ),
+                                                ],
+                                                dest: Some(
+                                                    Number(
+                                                        5,
+                                                    ),
+                                                ),
+                                                function_attributes: [
+                                                    AllocSize {
+                                                        elt_size: 0,
+                                                        num_elts: None,
+                                                    },
+                                                ],
+                                                is_tail_call: true,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                56: Edge(
+                                    Nil,
+                                ),
+                                57: Edge(
+                                    Nil,
+                                ),
+                                58: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                59: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "malloc",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            PointerType {
+                                                                addr_space: 0,
+                                                            },
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                60: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        4,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 72,
+                                                        },
+                                                    ),
+                                                ),
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                61: Edge(
+                                    Nil,
+                                ),
+                                62: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 72,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                63: Operation(
+                                    Instruction(
+                                        Call(
+                                            Call {
+                                                function: Right(
+                                                    ConstantOperand(
+                                                        ConstantRef(
+                                                            GlobalReference {
+                                                                name: Name(
+                                                                    "llvm.lifetime.start.p0",
+                                                                ),
+                                                                ty: TypeRef(
+                                                                    FuncType {
+                                                                        result_type: TypeRef(
+                                                                            VoidType,
+                                                                        ),
+                                                                        param_types: [
+                                                                            TypeRef(
+                                                                                IntegerType {
+                                                                                    bits: 64,
+                                                                                },
+                                                                            ),
+                                                                            TypeRef(
+                                                                                PointerType {
+                                                                                    addr_space: 0,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_var_arg: false,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ),
+                                                function_ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                                arguments: [
+                                                    (
+                                                        ConstantOperand(
+                                                            ConstantRef(
+                                                                Int {
+                                                                    bits: 64,
+                                                                    value: 4,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        [],
+                                                    ),
+                                                    (
+                                                        LocalOperand {
+                                                            name: Number(
+                                                                4,
+                                                            ),
+                                                            ty: TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        },
+                                                        [
+                                                            NonNull,
+                                                        ],
+                                                    ),
+                                                ],
+                                                return_attributes: [],
+                                                dest: None,
+                                                function_attributes: [],
+                                                is_tail_call: false,
+                                                calling_convention: C,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                64: Edge(
+                                    Nil,
+                                ),
+                                65: Edge(
+                                    Nil,
+                                ),
+                                66: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 64,
+                                                value: 4,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                67: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            GlobalReference {
+                                                name: Name(
+                                                    "llvm.lifetime.start.p0",
+                                                ),
+                                                ty: TypeRef(
+                                                    FuncType {
+                                                        result_type: TypeRef(
+                                                            VoidType,
+                                                        ),
+                                                        param_types: [
+                                                            TypeRef(
+                                                                IntegerType {
+                                                                    bits: 64,
+                                                                },
+                                                            ),
+                                                            TypeRef(
+                                                                PointerType {
+                                                                    addr_space: 0,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        is_var_arg: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                68: Operation(
+                                    Instruction(
+                                        Store(
+                                            Store {
+                                                address: LocalOperand {
+                                                    name: Number(
+                                                        3,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        PointerType {
+                                                            addr_space: 0,
+                                                        },
+                                                    ),
+                                                },
+                                                value: LocalOperand {
+                                                    name: Number(
+                                                        0,
+                                                    ),
+                                                    ty: TypeRef(
+                                                        IntegerType {
+                                                            bits: 32,
+                                                        },
+                                                    ),
+                                                },
+                                                volatile: true,
+                                                atomicity: None,
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                69: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    4,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                70: Edge(
+                                    Nil,
+                                ),
+                                71: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                72: Operation(
+                                    Instruction(
+                                        Alloca(
+                                            Alloca {
+                                                allocated_type: TypeRef(
+                                                    IntegerType {
+                                                        bits: 32,
+                                                    },
+                                                ),
+                                                num_elements: ConstantOperand(
+                                                    ConstantRef(
+                                                        Int {
+                                                            bits: 32,
+                                                            value: 1,
+                                                        },
+                                                    ),
+                                                ),
+                                                dest: Number(
+                                                    3,
+                                                ),
+                                                alignment: 4,
+                                                debugloc: None,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                                73: Edge(
+                                    Nil,
+                                ),
+                                74: Operation(
+                                    Constant(
+                                        ConstantRef(
+                                            Int {
+                                                bits: 32,
+                                                value: 1,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                            edge weights: {
+                                0: 0,
+                                1: 0,
+                                2: 1,
+                                3: 2,
+                                4: 0,
+                                5: 0,
+                                6: 0,
+                                7: 0,
+                                8: 1,
+                                9: 0,
+                                10: 1,
+                                11: 0,
+                                12: 0,
+                                13: 0,
+                                14: 0,
+                                15: 0,
+                                16: 1,
+                                17: 0,
+                                18: 1,
+                                19: 0,
+                                20: 0,
+                                21: 0,
+                                22: 0,
+                                23: 0,
+                                24: 1,
+                                25: 0,
+                                26: 0,
+                                27: 0,
+                                28: 1,
+                                29: 0,
+                                30: 0,
+                                31: 0,
+                                32: 0,
+                                33: 0,
+                                34: 0,
+                                35: 0,
+                                36: 1,
+                                37: 0,
+                                38: 1,
+                                39: 0,
+                                40: 0,
+                                41: 0,
+                                42: 0,
+                                43: 0,
+                                44: 1,
+                                45: 0,
+                                46: 1,
+                                47: 0,
+                                48: 0,
+                                49: 0,
+                                50: 0,
+                                51: 0,
+                                52: 1,
+                                53: 0,
+                                54: 0,
+                                55: 0,
+                                56: 0,
+                                57: 0,
+                                58: 1,
+                                59: 0,
+                                60: 0,
+                                61: 1,
+                                62: 2,
+                                63: 0,
+                                64: 0,
+                                65: 0,
+                                66: 0,
+                                67: 1,
+                                68: 0,
+                                69: 0,
+                                70: 0,
+                                71: 0,
+                                72: 0,
+                                73: 0,
+                            },
+                        },
+                    ),
+                    7: Edge(
+                        CF(
+                            None,
+                        ),
+                    ),
+                },
+                edge weights: {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 3,
+                    4: 4,
+                    5: 5,
+                    6: 0,
+                },
+            },
+        ),
+        4: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "global",
+                },
+            ),
+        ),
+        5: Edge(
+            FreeVar(
+                Symbol {
+                    symbol: "variables",
+                },
+            ),
+        ),
+        6: Operation(
+            GlobalVariable(
+                GlobalVariable {
+                    name: Name(
+                        "global",
+                    ),
+                    linkage: External,
+                    visibility: Default,
+                    is_constant: false,
+                    ty: TypeRef(
+                        PointerType {
+                            addr_space: 0,
+                        },
+                    ),
+                    addr_space: 0,
+                    dll_storage_class: Default,
+                    thread_local_mode: NotThreadLocal,
+                    unnamed_addr: None,
+                    initializer: Some(
+                        ConstantRef(
+                            Int {
+                                bits: 32,
+                                value: 5,
+                            },
+                        ),
+                    ),
+                    section: None,
+                    comdat: None,
+                    alignment: 4,
+                    debugloc: None,
+                },
+            ),
+        ),
+        7: Edge(
+            Nil,
+        ),
+        8: Operation(
+            Constant(
+                ConstantRef(
+                    Int {
+                        bits: 32,
+                        value: 5,
+                    },
+                ),
+            ),
+        ),
+    },
+    edge weights: {
+        0: 0,
+        1: 1,
+        2: 2,
+        3: 3,
+        4: 0,
+        5: 0,
+        6: 0,
+        7: 0,
+    },
+}

--- a/sd-core/src/language/spartan.rs
+++ b/sd-core/src/language/spartan.rs
@@ -29,6 +29,14 @@ impl super::Language for Spartan {
     type Symbol = Empty;
 }
 
+impl TryFrom<<Spartan as super::Language>::Addr> for <Spartan as super::Language>::Symbol {
+    type Error = &'static str;
+
+    fn try_from(_: <Spartan as super::Language>::Addr) -> Result<Self, Self::Error> {
+        Err("no symbols in sd-lang")
+    }
+}
+
 pub type Expr = super::Expr<Spartan>;
 pub type Bind = super::Bind<Spartan>;
 pub type Value = super::Value<Spartan>;

--- a/sd-core/src/prettyprinter/llvm_ir.rs
+++ b/sd-core/src/prettyprinter/llvm_ir.rs
@@ -1,0 +1,35 @@
+use llvm_ir::Name;
+use pretty::RcDoc;
+
+use super::PrettyPrint;
+use crate::language::llvm_ir::{Expr, Op, Thunk, Var};
+
+impl PrettyPrint for Op {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
+        RcDoc::text(self.to_string())
+    }
+}
+
+impl PrettyPrint for Name {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
+        RcDoc::text(self.to_string())
+    }
+}
+
+impl PrettyPrint for Var {
+    fn to_doc(&self) -> RcDoc<'_, ()> {
+        RcDoc::text(self.to_string())
+    }
+}
+
+impl PrettyPrint for Expr {
+    fn to_doc(&self) -> pretty::RcDoc<'_, ()> {
+        RcDoc::nil() // TODO: Implement pretty printing for LLVM IR
+    }
+}
+
+impl PrettyPrint for Thunk {
+    fn to_doc(&self) -> pretty::RcDoc<'_, ()> {
+        RcDoc::nil() // TODO: Implement pretty printing for LLVM IR
+    }
+}

--- a/sd-core/src/prettyprinter/mod.rs
+++ b/sd-core/src/prettyprinter/mod.rs
@@ -4,6 +4,7 @@ use itertools::Either;
 use pretty::RcDoc;
 
 pub mod chil;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod llvm_ir;
 pub mod mlir;
 pub mod spartan;

--- a/sd-core/src/prettyprinter/mod.rs
+++ b/sd-core/src/prettyprinter/mod.rs
@@ -4,6 +4,7 @@ use itertools::Either;
 use pretty::RcDoc;
 
 pub mod chil;
+pub mod llvm_ir;
 pub mod mlir;
 pub mod spartan;
 
@@ -28,6 +29,18 @@ pub fn list<'a, T: 'a + PrettyPrint>(ts: impl IntoIterator<Item = &'a T>) -> RcD
 /// Comma-separated list with parentheses around it.
 pub fn paran_list<'a, T: 'a + PrettyPrint>(ts: impl IntoIterator<Item = &'a T>) -> RcDoc<'a, ()> {
     RcDoc::text("(").append(list(ts)).append(RcDoc::text(")"))
+}
+
+impl PrettyPrint for String {
+    fn to_doc(&self) -> pretty::RcDoc<()> {
+        pretty::RcDoc::text(self)
+    }
+}
+
+impl PrettyPrint for Box<String> {
+    fn to_doc(&self) -> pretty::RcDoc<()> {
+        pretty::RcDoc::text(self.as_ref())
+    }
 }
 
 impl<T: PrettyPrint> PrettyPrint for Vec<T> {

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_add.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_add.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_alias.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_alias.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_diverge.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_diverge.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_fact.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_fact.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_hello.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_hello.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_ifunc.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_ifunc.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_jump.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_jump.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_linkedlist.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_linkedlist.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_loop.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_loop.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_mutual_diverge.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_mutual_diverge.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_switch.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_switch.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-core/src/snapshots/sd_core__graph__tests__free_vars_variables.llvm-ir.snap
+++ b/sd-core/src/snapshots/sd_core__graph__tests__free_vars_variables.llvm-ir.snap
@@ -1,0 +1,5 @@
+---
+source: sd-core/src/graph.rs
+expression: expr.free_var_test()
+---
+{}

--- a/sd-gui/src/graph_ui.rs
+++ b/sd-gui/src/graph_ui.rs
@@ -17,7 +17,7 @@ use sd_core::{
         traits::{Graph, WithType},
     },
     interactive::InteractiveGraph,
-    language::{chil::Chil, mlir::Mlir, spartan::Spartan},
+    language::{chil::Chil, llvm_ir::LlvmIr, mlir::Mlir, spartan::Spartan},
     lp::Solver,
 };
 use sd_graphics::{
@@ -29,6 +29,7 @@ use crate::shape_generator::generate_shapes;
 
 pub enum GraphUi {
     Chil(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<Chil>>>),
+    LlvmIr(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<LlvmIr>>>),
     Mlir(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<Mlir>>>),
     Spartan(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<Spartan>>>),
     Dot(GraphUiInternal<InteractiveGraph<Hypergraph<DotWeight>>>),
@@ -37,6 +38,10 @@ pub enum GraphUi {
 impl GraphUi {
     pub(crate) fn new_chil(graph: SyntaxHypergraph<Chil>, solver: Solver) -> Self {
         Self::Chil(GraphUiInternal::new(InteractiveGraph::new(graph), solver))
+    }
+
+    pub(crate) fn new_llvm_ir(graph: SyntaxHypergraph<LlvmIr>, solver: Solver) -> Self {
+        Self::LlvmIr(GraphUiInternal::new(InteractiveGraph::new(graph), solver))
     }
 
     pub(crate) fn new_mlir(graph: SyntaxHypergraph<Mlir>, solver: Solver) -> Self {
@@ -54,6 +59,7 @@ impl GraphUi {
     delegate! {
         to match self {
             GraphUi::Chil(graph_ui) => graph_ui,
+            GraphUi::LlvmIr(graph_ui) => graph_ui,
             GraphUi::Mlir(graph_ui) => graph_ui,
             GraphUi::Spartan(graph_ui) => graph_ui,
             GraphUi::Dot(graph_ui) => graph_ui
@@ -71,6 +77,7 @@ impl GraphUi {
     delegate! {
         to match self {
             GraphUi::Chil(graph_ui) => graph_ui.graph,
+            GraphUi::LlvmIr(graph_ui) => graph_ui.graph,
             GraphUi::Mlir(graph_ui) => graph_ui.graph,
             GraphUi::Spartan(graph_ui) => graph_ui.graph,
             GraphUi::Dot(graph_ui) => graph_ui.graph

--- a/sd-gui/src/graph_ui.rs
+++ b/sd-gui/src/graph_ui.rs
@@ -5,6 +5,8 @@ use std::fmt::Display;
 use delegate::delegate;
 use eframe::egui;
 use egui::{CornerRadius, Pos2, Rect, Scene, Vec2};
+#[cfg(not(target_arch = "wasm32"))]
+use sd_core::language::llvm_ir::LlvmIr;
 use sd_core::{
     codeable::Codeable,
     common::{Direction, Matchable},
@@ -17,7 +19,7 @@ use sd_core::{
         traits::{Graph, WithType},
     },
     interactive::InteractiveGraph,
-    language::{chil::Chil, llvm_ir::LlvmIr, mlir::Mlir, spartan::Spartan},
+    language::{chil::Chil, mlir::Mlir, spartan::Spartan},
     lp::Solver,
 };
 use sd_graphics::{
@@ -29,6 +31,7 @@ use crate::shape_generator::generate_shapes;
 
 pub enum GraphUi {
     Chil(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<Chil>>>),
+    #[cfg(not(target_arch = "wasm32"))]
     LlvmIr(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<LlvmIr>>>),
     Mlir(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<Mlir>>>),
     Spartan(GraphUiInternal<InteractiveGraph<SyntaxHypergraph<Spartan>>>),
@@ -40,6 +43,7 @@ impl GraphUi {
         Self::Chil(GraphUiInternal::new(InteractiveGraph::new(graph), solver))
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn new_llvm_ir(graph: SyntaxHypergraph<LlvmIr>, solver: Solver) -> Self {
         Self::LlvmIr(GraphUiInternal::new(InteractiveGraph::new(graph), solver))
     }
@@ -59,6 +63,7 @@ impl GraphUi {
     delegate! {
         to match self {
             GraphUi::Chil(graph_ui) => graph_ui,
+            #[cfg(not(target_arch = "wasm32"))]
             GraphUi::LlvmIr(graph_ui) => graph_ui,
             GraphUi::Mlir(graph_ui) => graph_ui,
             GraphUi::Spartan(graph_ui) => graph_ui,
@@ -77,6 +82,7 @@ impl GraphUi {
     delegate! {
         to match self {
             GraphUi::Chil(graph_ui) => graph_ui.graph,
+            #[cfg(not(target_arch = "wasm32"))]
             GraphUi::LlvmIr(graph_ui) => graph_ui.graph,
             GraphUi::Mlir(graph_ui) => graph_ui.graph,
             GraphUi::Spartan(graph_ui) => graph_ui.graph,

--- a/sd-gui/src/main.rs
+++ b/sd-gui/src/main.rs
@@ -34,6 +34,10 @@ struct Args {
     #[arg(long, value_name = "FILE")]
     spartan: Option<PathBuf>,
 
+    /// Read in an llvm ir file
+    #[arg(long, value_name = "FILE")]
+    llvm_ir: Option<PathBuf>,
+
     /// Read in an mlir file
     #[arg(long, value_name = "FILE")]
     mlir: Option<PathBuf>,
@@ -77,6 +81,9 @@ fn main() -> anyhow::Result<()> {
     } else if let Some(path) = args.spartan {
         let code = std::fs::read_to_string(path)?;
         Some((code, sd_gui::UiLanguage::Spartan))
+    } else if let Some(path) = args.llvm_ir {
+        let code = std::fs::read_to_string(path)?;
+        Some((code, sd_gui::UiLanguage::LlvmIr))
     } else if let Some(path) = args.mlir {
         let code = std::fs::read_to_string(path)?;
         Some((code, sd_gui::UiLanguage::Mlir))

--- a/sd-gui/src/selection.rs
+++ b/sd-gui/src/selection.rs
@@ -5,7 +5,7 @@ use eframe::egui;
 use sd_core::{
     graph::SyntaxHypergraph,
     interactive::InteractiveSubgraph,
-    language::{Expr, Language, Thunk, chil::Chil, mlir::Mlir, spartan::Spartan},
+    language::{Expr, Language, Thunk, chil::Chil, llvm_ir::LlvmIr, mlir::Mlir, spartan::Spartan},
     lp::Solver,
     prettyprinter::PrettyPrint,
 };
@@ -19,6 +19,7 @@ use crate::{
 
 pub enum Selection {
     Chil(SelectionInternal<Chil>),
+    LlvmIr(SelectionInternal<LlvmIr>),
     Mlir(SelectionInternal<Mlir>),
     Spartan(SelectionInternal<Spartan>),
 }
@@ -27,6 +28,7 @@ impl Selection {
     delegate! {
         to match self {
             Self::Chil(selection) => selection,
+            Self::LlvmIr(selection) => selection,
             Self::Mlir(selection) => selection,
             Self::Spartan(selection) => selection,
         } {
@@ -39,6 +41,11 @@ impl Selection {
     pub fn from_graph(graph_ui: &GraphUi, name: String, solver: Solver) -> Option<Self> {
         match graph_ui {
             GraphUi::Chil(graph_ui) => Some(Self::Chil(SelectionInternal::new(
+                graph_ui.graph.to_subgraph(),
+                name,
+                solver,
+            ))),
+            GraphUi::LlvmIr(graph_ui) => Some(Self::LlvmIr(SelectionInternal::new(
                 graph_ui.graph.to_subgraph(),
                 name,
                 solver,

--- a/sd-gui/src/selection.rs
+++ b/sd-gui/src/selection.rs
@@ -2,10 +2,12 @@
 
 use delegate::delegate;
 use eframe::egui;
+#[cfg(not(target_arch = "wasm32"))]
+use sd_core::language::llvm_ir::LlvmIr;
 use sd_core::{
     graph::SyntaxHypergraph,
     interactive::InteractiveSubgraph,
-    language::{Expr, Language, Thunk, chil::Chil, llvm_ir::LlvmIr, mlir::Mlir, spartan::Spartan},
+    language::{Expr, Language, Thunk, chil::Chil, mlir::Mlir, spartan::Spartan},
     lp::Solver,
     prettyprinter::PrettyPrint,
 };
@@ -19,6 +21,7 @@ use crate::{
 
 pub enum Selection {
     Chil(SelectionInternal<Chil>),
+    #[cfg(not(target_arch = "wasm32"))]
     LlvmIr(SelectionInternal<LlvmIr>),
     Mlir(SelectionInternal<Mlir>),
     Spartan(SelectionInternal<Spartan>),
@@ -28,6 +31,7 @@ impl Selection {
     delegate! {
         to match self {
             Self::Chil(selection) => selection,
+            #[cfg(not(target_arch = "wasm32"))]
             Self::LlvmIr(selection) => selection,
             Self::Mlir(selection) => selection,
             Self::Spartan(selection) => selection,
@@ -45,6 +49,7 @@ impl Selection {
                 name,
                 solver,
             ))),
+            #[cfg(not(target_arch = "wasm32"))]
             GraphUi::LlvmIr(graph_ui) => Some(Self::LlvmIr(SelectionInternal::new(
                 graph_ui.graph.to_subgraph(),
                 name,


### PR DESCRIPTION
This is ready for a review.

A few minor TODOs:
- [x] conditionally don't-compile for LLVM IR on WASM
- [ ] change `OpInfo` to avoid having to use `TryFrom`
- [x] check `nix build` still works
- [ ] maybe merge `LlvmIrSettings` and `MlirSettings`?